### PR TITLE
 Use context from `completion.CmdCompletionOrList.CandidatesContext` instead of `conte xt.TODO()`

### DIFF
--- a/interactive.go
+++ b/interactive.go
@@ -147,10 +147,10 @@ func (ss *session) newInteractiveIn() *interactiveIn {
 	editor.SetWriter(ss.termOut)
 
 	editor.BindKey(keys.CtrlI, &completion.CmdCompletionOrList{
-		Enclosure:  `"'`,
-		Delimiter:  ",",
-		Postfix:    " ",
-		Candidates: sqlcompletion.New(ss.Dialect, ss.conn),
+		Enclosure:         `"'`,
+		Delimiter:         ",",
+		Postfix:           " ",
+		CandidatesContext: sqlcompletion.New(ss.Dialect, ss.conn),
 	})
 	editor.SubmitOnEnterWhen(func(lines []string, csrline int) bool {
 		if len(lines) > 0 && isOneLineCommand(lines[0]) {

--- a/release_note_en.md
+++ b/release_note_en.md
@@ -8,6 +8,7 @@
 
 - Updated internal dependencies (go-multiline-ny v0.22.1, go-box v3) (#4)
 - Removed obsolete go-box v2 references (#4)
+- Use context from completion.CmdCompletionOrList.CandidatesContext instead of context.TODO()
 
 v0.24.0
 =======

--- a/release_note_ja.md
+++ b/release_note_ja.md
@@ -8,6 +8,7 @@
 
 - 依存パッケージを更新 (go-multiline-ny v0.22.1, go-box v3) (#4)
 - go-box v2 への参照を削除 (#4)
+- テーブル名・カラム名補完の際に使用していた `context.TODO()` を `completion.CmdCompletionOrList.CandidatesContext` が提供するコンテキストに変更
 
 v0.24.0
 =======


### PR DESCRIPTION
## Changes in this pull request (English)

Replaced `context.TODO()` with the context provided by `completion.CmdCompletionOrList.CandidatesContext`.  
This allows proper context propagation from `go-multiline-ny` during table/column name completions, enabling cancellation and timeout handling.

## Changes in this pull request (Japanese)

テーブル名・カラム名補完の際に使用していた `context.TODO()` を、`completion.CmdCompletionOrList.CandidatesContext` が提供するコンテキストに変更しました。  これにより、`go-multiline-ny` 側からのキャンセルやタイムアウトの伝播が正しく行われるようになります。