### PR TITLE
Migrate SQLite3 tests from PowerShell 7 to Go’s standard go test framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,7 @@ all:
 	$(SET) "CGO_ENABLED=0" && $(GO) build $(GOOPT) && $(GO) build -C "$(CURDIR)/cmd/sqlbless" -o "$(CURDIR)/$(NAME)$(EXE)" $(GOOPT)
 
 test:
-ifeq ($(OS),Windows_NT)
-	pwsh "test/test-sqlite3.ps1"
-#	pwsh "test/test.ps1"
-endif
-	$(GO) test -v
+	$(GO) test -v ./...
 
 _dist:
 	$(MAKE) all

--- a/interactive.go
+++ b/interactive.go
@@ -94,7 +94,10 @@ func (i *interactiveIn) Read(ctx context.Context) ([]string, error) {
 		w.Flush()
 		return []string{}, nil
 	}
-	return lines, err
+	if err != nil {
+		return nil, fmt.Errorf("interactiveIn.Read: %w", err)
+	}
+	return lines, nil
 }
 
 func (i *interactiveIn) GetKey() (string, error) {

--- a/loop.go
+++ b/loop.go
@@ -103,7 +103,7 @@ func (ss *session) Loop(ctx context.Context, commandIn commandIn) error {
 				}
 				return nil
 			}
-			return err
+			return fmt.Errorf("commandIn.Read: %w", err)
 		}
 		queryAndTerm := strings.Join(lines, "\n")
 		query, _ := misc.HasTerm(queryAndTerm, ss.Term)
@@ -262,11 +262,11 @@ func (cfg *Config) Run(driver, dataSourceName string, dbDialect *dialect.Entry) 
 	defer db.Close()
 
 	if err = db.Ping(); err != nil {
-		return err
+		return fmt.Errorf("db.Ping: %w", err)
 	}
 	conn, err := db.Conn(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("db.Conn: %w", err)
 	}
 	defer conn.Close()
 
@@ -287,9 +287,8 @@ func (cfg *Config) Run(driver, dataSourceName string, dbDialect *dialect.Entry) 
 		return ss.Start(ctx, cfg.Script)
 	}
 
-	if !term.IsTerminal(int(os.Stdin.Fd())) {
+	if !term.IsTerminal(int(os.Stdin.Fd())) && !ss.automatic() {
 		return ss.StartFromStdin(ctx)
 	}
-
 	return ss.Loop(ctx, ss.newInteractiveIn())
 }

--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func Run() error {
 	}
 	d, err := dialect.ReadDBInfoFromArgs(args)
 	if err != nil {
-		return err
+		return fmt.Errorf("dialect.ReadDBInfoFromArgs: %w", err)
 	}
 	if cfg.Debug {
 		fmt.Fprintln(os.Stderr, d.DataSource)

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,82 @@
+package sqlbless
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hymkor/sqlbless/dialect"
+	_ "github.com/hymkor/sqlbless/dialect/sqlite"
+)
+
+func disableColor() (restore func()) {
+	if noColor, ok := os.LookupEnv("NO_COLOR"); ok {
+		restore = func() { os.Setenv("NO_COLOR", noColor) }
+	} else {
+		restore = func() { os.Unsetenv("NO_COLOR") }
+	}
+	os.Setenv("NO_COLOR", "1")
+	return
+}
+
+func TestConfigRun(t *testing.T) {
+	restoreColor := disableColor()
+	defer restoreColor()
+
+	testLst := filepath.Join(t.TempDir(), "output.lst")
+	auto :=
+		"CREATE TABLE TESTTBL|" +
+			"( TESTNO  NUMERIC ,|" +
+			"  DT      CHARACTER VARYING(20) ,|" +
+			" PRIMARY  KEY (TESTNO) )||" +
+			"INSERT INTO TESTTBL VALUES|" +
+			"(10,'2024-05-25 13:45:33')||" +
+			"COMMIT||" +
+			"EDIT TESTTBL||" +
+			"/10|lr2015-06-07 20:21:22|cyy" +
+			"SPOOL " + testLst + "||" +
+			"SELECT * FROM TESTTBL||" +
+			"SPOOL OFF||" +
+			"ROLLBACK||" +
+			"EXIT||"
+
+	cfg := New()
+	cfg.Auto = auto
+	cfg.Debug = true
+	d, err := dialect.ReadDBInfoFromArgs([]string{"sqlite3", ":memory:"})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	err = cfg.Run(d.Driver, d.DataSource, d.Dialect)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	fd, err := os.Open(testLst)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer fd.Close()
+	sc := bufio.NewScanner(fd)
+	count := 0
+	for sc.Scan() {
+		line := sc.Text()
+		if len(line) > 0 && line[0] == '#' {
+			continue
+		}
+		count++
+		if count == 1 {
+			continue
+		}
+		field := strings.Split(line, ",")
+		if len(field) >= 2 && field[1] == "2015-06-07 20:21:22" {
+			// OK
+			return
+		}
+	}
+	if sc.Err() != nil {
+		t.Fatal(err.Error())
+	}
+	t.Fatalf("%s: not found", "2015-06-07 20:21:22")
+}

--- a/release_note_en.md
+++ b/release_note_en.md
@@ -10,6 +10,7 @@
 - Updated internal dependencies (go-multiline-ny v0.22.1, go-box v3) (#4)
 - Removed obsolete go-box v2 references (#4)
 - Use context from completion.CmdCompletionOrList.CandidatesContext instead of context.TODO()
+- Rewrote the SQLite3 test written in PowerShell 7 using Go’s standard `go test` framework to enable testing on Linux and GitHub Actions.
 
 v0.24.0
 =======

--- a/release_note_ja.md
+++ b/release_note_ja.md
@@ -10,6 +10,7 @@
 - 依存パッケージを更新 (go-multiline-ny v0.22.1, go-box v3) (#4)
 - go-box v2 への参照を削除 (#4)
 - テーブル名・カラム名補完の際に使用していた `context.TODO()` を `completion.CmdCompletionOrList.CandidatesContext` が提供するコンテキストに変更
+- Linux 環境や GitHub Actions からテストができるよう、PowerShell 7 で記述していた SQLite3 を使ったテストを、go test に置き変えた。
 
 v0.24.0
 =======


### PR DESCRIPTION
## Changes in this pull request (English)

Rewrote the SQLite3 tests, previously written in PowerShell 7, to use Go’s standard `go test` framework.  
This enables running tests on Linux and in GitHub Actions environments.

## Changes in this pull request (Japanese)

PowerShell 7 で記述していた SQLite3 を使用したテストを、Go 標準の `go test` フレームワークに書き換えました。  
これにより、Linux 環境や GitHub Actions 上でもテストを実行できるようになります。
