### PR TITLE
Refactor `dialect` subpackage: rename fields and methods for clarity

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -158,7 +158,7 @@ func doDescColumns(ctx context.Context, ss *session, table string) error {
 	if ss.Dialect.SQLForColumns == "" {
 		return fmt.Errorf("desc table: %w", ErrNotSupported)
 	}
-	query := ss.Dialect.SqlToQueryColumns(table)
+	query := ss.Dialect.BuildSQLForColumns(table)
 	if ss.Debug {
 		fmt.Println(query)
 	}

--- a/commands.go
+++ b/commands.go
@@ -106,7 +106,7 @@ func doDescTables(ctx context.Context, ss *session, commandIn commandIn) error {
 		}
 		header := e.Front()
 		for i, c := range header.Cell {
-			if strings.EqualFold(c.Text(), ss.Dialect.TableField) {
+			if strings.EqualFold(c.Text(), ss.Dialect.TableNameField) {
 				name = e.CursorRow.Cell[i].Text()
 				return &csvi.CommandResult{Quit: true}, nil
 			}

--- a/commands.go
+++ b/commands.go
@@ -94,7 +94,7 @@ func (ss *session) beginTx(ctx context.Context, w io.Writer) error {
 }
 
 func doDescTables(ctx context.Context, ss *session, commandIn commandIn) error {
-	if ss.Dialect.SqlForTab == "" {
+	if ss.Dialect.SQLForTables == "" {
 		return fmt.Errorf("desc: %w", ErrNotSupported)
 	}
 	query := ss.Dialect.SqlToQueryTables()

--- a/commands.go
+++ b/commands.go
@@ -155,7 +155,7 @@ func doDescTables(ctx context.Context, ss *session, commandIn commandIn) error {
 }
 
 func doDescColumns(ctx context.Context, ss *session, table string) error {
-	if ss.Dialect.SqlForDesc == "" {
+	if ss.Dialect.SQLForColumns == "" {
 		return fmt.Errorf("desc table: %w", ErrNotSupported)
 	}
 	query := ss.Dialect.SqlToQueryColumns(table)

--- a/commands.go
+++ b/commands.go
@@ -97,7 +97,7 @@ func doDescTables(ctx context.Context, ss *session, commandIn commandIn) error {
 	if ss.Dialect.SQLForTables == "" {
 		return fmt.Errorf("desc: %w", ErrNotSupported)
 	}
-	query := ss.Dialect.SqlToQueryTables()
+	query := ss.Dialect.BuildSQLForTables()
 	var name string
 
 	handler := func(e *csvi.KeyEventArgs) (*csvi.CommandResult, error) {

--- a/dialect/main.go
+++ b/dialect/main.go
@@ -27,7 +27,7 @@ type Entry struct {
 	SQLForColumns       string
 	SQLForTables        string
 	TableNameField      string
-	ColumnField         string
+	ColumnNameField     string
 	PlaceHolder         PlaceHolder
 	TypeConverterFor    func(typeName string) func(literal string) (any, error)
 	DSNFilter           func(string) (string, error)

--- a/dialect/main.go
+++ b/dialect/main.go
@@ -25,7 +25,7 @@ type PlaceHolder interface {
 type Entry struct {
 	Usage               string
 	SQLForColumns       string
-	SqlForTab           string
+	SQLForTables        string
 	TableField          string
 	ColumnField         string
 	PlaceHolder         PlaceHolder

--- a/dialect/main.go
+++ b/dialect/main.go
@@ -85,8 +85,8 @@ func ParseAnyDateTime(s string) (time.Time, error) {
 
 var registry = map[string]*Entry{}
 
-func Register(name string, setting *Entry) {
-	registry[strings.ToUpper(name)] = setting
+func (e *Entry) Register(name string) {
+	registry[strings.ToUpper(name)] = e
 }
 
 func Find(name string) (*Entry, bool) {

--- a/dialect/main.go
+++ b/dialect/main.go
@@ -29,17 +29,17 @@ type Entry struct {
 	TableField          string
 	ColumnField         string
 	PlaceHolder         PlaceHolder
-	TypeNameToConv      func(string) func(string) (any, error)
+	TypeConverterFor    func(typeName string) func(literal string) (any, error)
 	DSNFilter           func(string) (string, error)
 	CanUseInTransaction func(string) bool
 	IsQuerySQL          func(string) bool
 }
 
 func (D *Entry) TypeToConv(typeName string) func(string) (any, error) {
-	if D.TypeNameToConv == nil {
+	if D.TypeConverterFor == nil {
 		return nil
 	}
-	return D.TypeNameToConv(typeName)
+	return D.TypeConverterFor(typeName)
 }
 
 const (

--- a/dialect/main.go
+++ b/dialect/main.go
@@ -23,17 +23,16 @@ type PlaceHolder interface {
 }
 
 type Entry struct {
-	Usage                 string
-	SqlForDesc            string
-	SqlForTab             string
-	TableField            string
-	ColumnField           string
-	DisplayDateTimeLayout string
-	PlaceHolder           PlaceHolder
-	TypeNameToConv        func(string) func(string) (any, error)
-	DSNFilter             func(string) (string, error)
-	CanUseInTransaction   func(string) bool
-	IsQuerySQL            func(string) bool
+	Usage               string
+	SqlForDesc          string
+	SqlForTab           string
+	TableField          string
+	ColumnField         string
+	PlaceHolder         PlaceHolder
+	TypeNameToConv      func(string) func(string) (any, error)
+	DSNFilter           func(string) (string, error)
+	CanUseInTransaction func(string) bool
+	IsQuerySQL          func(string) bool
 }
 
 func (D *Entry) TypeToConv(typeName string) func(string) (any, error) {

--- a/dialect/main.go
+++ b/dialect/main.go
@@ -23,16 +23,16 @@ type PlaceHolder interface {
 }
 
 type Entry struct {
-	Usage               string
-	SQLForColumns       string
-	SQLForTables        string
-	TableNameField      string
-	ColumnNameField     string
-	PlaceHolder         PlaceHolder
-	TypeConverterFor    func(typeName string) func(literal string) (any, error)
-	DSNFilter           func(string) (string, error)
-	CanUseInTransaction func(string) bool
-	IsQuerySQL          func(string) bool
+	Usage             string
+	SQLForColumns     string
+	SQLForTables      string
+	TableNameField    string
+	ColumnNameField   string
+	PlaceHolder       PlaceHolder
+	TypeConverterFor  func(typeName string) func(literal string) (any, error)
+	DSNFilter         func(string) (string, error)
+	IsTransactionSafe func(string) bool
+	IsQuerySQL        func(string) bool
 }
 
 func (D *Entry) LookupConverter(typeName string) func(string) (any, error) {

--- a/dialect/main.go
+++ b/dialect/main.go
@@ -23,16 +23,36 @@ type PlaceHolder interface {
 }
 
 type Entry struct {
-	Usage             string
-	SQLForColumns     string
-	SQLForTables      string
-	TableNameField    string
-	ColumnNameField   string
-	PlaceHolder       PlaceHolder
-	TypeConverterFor  func(typeName string) func(literal string) (any, error)
-	DSNFilter         func(string) (string, error)
-	IsTransactionSafe func(string) bool
-	IsQuerySQL        func(string) bool
+	// Usage describes how to use this entry or what it represents.
+	Usage string
+
+	// SQLForColumns is the SQL query used to retrieve column information.
+	SQLForColumns string
+
+	// SQLForTables is the SQL query used to retrieve table information.
+	SQLForTables string
+
+	// TableNameField is the field name for table names in SQL results.
+	TableNameField string
+
+	// ColumnNameField is the field name for column names in SQL results.
+	ColumnNameField string
+
+	// PlaceHolder defines how to represent placeholders (e.g., ?, $1) in SQL.
+	PlaceHolder PlaceHolder
+
+	// TypeConverterFor returns a converter function for a given type name.
+	// The returned function converts a string literal to the corresponding Go value.
+	TypeConverterFor func(typeName string) func(literal string) (any, error)
+
+	// DSNFilter adjusts or validates a given DSN string before use.
+	DSNFilter func(dsn string) (string, error)
+
+	// IsTransactionSafe reports whether the given SQL statement is safe to run in a transaction.
+	IsTransactionSafe func(sql string) bool
+
+	// IsQuerySQL reports whether the given SQL statement is a query (e.g., SELECT) or not.
+	IsQuerySQL func(sql string) bool
 }
 
 func (D *Entry) LookupConverter(typeName string) func(string) (any, error) {

--- a/dialect/main.go
+++ b/dialect/main.go
@@ -26,7 +26,7 @@ type Entry struct {
 	Usage               string
 	SQLForColumns       string
 	SQLForTables        string
-	TableField          string
+	TableNameField      string
 	ColumnField         string
 	PlaceHolder         PlaceHolder
 	TypeConverterFor    func(typeName string) func(literal string) (any, error)

--- a/dialect/main.go
+++ b/dialect/main.go
@@ -35,7 +35,7 @@ type Entry struct {
 	IsQuerySQL          func(string) bool
 }
 
-func (D *Entry) TypeToConv(typeName string) func(string) (any, error) {
+func (D *Entry) LookupConverter(typeName string) func(string) (any, error) {
 	if D.TypeConverterFor == nil {
 		return nil
 	}

--- a/dialect/main.go
+++ b/dialect/main.go
@@ -24,7 +24,7 @@ type PlaceHolder interface {
 
 type Entry struct {
 	Usage               string
-	SqlForDesc          string
+	SQLForColumns       string
 	SqlForTab           string
 	TableField          string
 	ColumnField         string

--- a/dialect/mysql/main.go
+++ b/dialect/mysql/main.go
@@ -91,7 +91,7 @@ var mySqlSpec = &dialect.Entry{
 	PlaceHolder:      &dialect.PlaceHolderQuestion{},
 	DSNFilter:        mySQLDSNFilter,
 	TableNameField:   "TABLE_NAME",
-	ColumnField:      "NAME",
+	ColumnNameField:  "NAME",
 }
 
 func init() {

--- a/dialect/mysql/main.go
+++ b/dialect/mysql/main.go
@@ -87,12 +87,11 @@ var mySqlSpec = &dialect.Entry{
          where table_type = 'BASE TABLE'
            and table_schema 
         not in ('mysql', 'information_schema', 'performance_schema', 'sys')`,
-	DisplayDateTimeLayout: dialect.DateTimeTzLayout,
-	TypeNameToConv:        mySQLTypeNameToConv,
-	PlaceHolder:           &dialect.PlaceHolderQuestion{},
-	DSNFilter:             mySQLDSNFilter,
-	TableField:            "TABLE_NAME",
-	ColumnField:           "NAME",
+	TypeNameToConv: mySQLTypeNameToConv,
+	PlaceHolder:    &dialect.PlaceHolderQuestion{},
+	DSNFilter:      mySQLDSNFilter,
+	TableField:     "TABLE_NAME",
+	ColumnField:    "NAME",
 }
 
 func init() {

--- a/dialect/mysql/main.go
+++ b/dialect/mysql/main.go
@@ -90,7 +90,7 @@ var mySqlSpec = &dialect.Entry{
 	TypeConverterFor: mySQLTypeNameToConv,
 	PlaceHolder:      &dialect.PlaceHolderQuestion{},
 	DSNFilter:        mySQLDSNFilter,
-	TableField:       "TABLE_NAME",
+	TableNameField:   "TABLE_NAME",
 	ColumnField:      "NAME",
 }
 

--- a/dialect/mysql/main.go
+++ b/dialect/mysql/main.go
@@ -87,11 +87,11 @@ var mySqlSpec = &dialect.Entry{
          where table_type = 'BASE TABLE'
            and table_schema 
         not in ('mysql', 'information_schema', 'performance_schema', 'sys')`,
-	TypeNameToConv: mySQLTypeNameToConv,
-	PlaceHolder:    &dialect.PlaceHolderQuestion{},
-	DSNFilter:      mySQLDSNFilter,
-	TableField:     "TABLE_NAME",
-	ColumnField:    "NAME",
+	TypeConverterFor: mySQLTypeNameToConv,
+	PlaceHolder:      &dialect.PlaceHolderQuestion{},
+	DSNFilter:        mySQLDSNFilter,
+	TableField:       "TABLE_NAME",
+	ColumnField:      "NAME",
 }
 
 func init() {

--- a/dialect/mysql/main.go
+++ b/dialect/mysql/main.go
@@ -65,7 +65,7 @@ func mySQLDSNFilter(dsn string) (string, error) {
 
 var mySqlSpec = &dialect.Entry{
 	Usage: `sqlbless mysql <USERNAME>:<PASSWORD>@/<DBNAME>`,
-	SqlForDesc: `
+	SQLForColumns: `
         select ordinal_position as "ID",
                column_name as "NAME",
                case

--- a/dialect/mysql/main.go
+++ b/dialect/mysql/main.go
@@ -82,7 +82,7 @@ var mySqlSpec = &dialect.Entry{
           from information_schema.columns
          where table_name = ?
          order by ordinal_position`,
-	SqlForTab: `
+	SQLForTables: `
         select * from information_schema.tables
          where table_type = 'BASE TABLE'
            and table_schema 

--- a/dialect/mysql/main.go
+++ b/dialect/mysql/main.go
@@ -95,5 +95,5 @@ var mySqlSpec = &dialect.Entry{
 }
 
 func init() {
-	dialect.Register("MYSQL", mySqlSpec)
+	mySqlSpec.Register("MYSQL")
 }

--- a/dialect/oracle/main.go
+++ b/dialect/oracle/main.go
@@ -38,7 +38,7 @@ var oracleSpec = &dialect.Entry{
 	SQLForTables:     `select * from tab where tname not like 'BIN$%'`,
 	TypeConverterFor: oracleTypeNameToConv,
 	TableNameField:   "tname",
-	ColumnField:      "name",
+	ColumnNameField:  "name",
 	PlaceHolder:      &dialect.PlaceHolderName{Prefix: ":", Format: "v"},
 }
 

--- a/dialect/oracle/main.go
+++ b/dialect/oracle/main.go
@@ -35,12 +35,11 @@ var oracleSpec = &dialect.Entry{
 	from all_tab_columns
    where table_name = UPPER(:1)
    order by column_id`,
-	SqlForTab:             `select * from tab where tname not like 'BIN$%'`,
-	DisplayDateTimeLayout: dialect.DateTimeTzLayout,
-	TypeNameToConv:        oracleTypeNameToConv,
-	TableField:            "tname",
-	ColumnField:           "name",
-	PlaceHolder:           &dialect.PlaceHolderName{Prefix: ":", Format: "v"},
+	SqlForTab:      `select * from tab where tname not like 'BIN$%'`,
+	TypeNameToConv: oracleTypeNameToConv,
+	TableField:     "tname",
+	ColumnField:    "name",
+	PlaceHolder:    &dialect.PlaceHolderName{Prefix: ":", Format: "v"},
 }
 
 func init() {

--- a/dialect/oracle/main.go
+++ b/dialect/oracle/main.go
@@ -37,7 +37,7 @@ var oracleSpec = &dialect.Entry{
    order by column_id`,
 	SQLForTables:     `select * from tab where tname not like 'BIN$%'`,
 	TypeConverterFor: oracleTypeNameToConv,
-	TableField:       "tname",
+	TableNameField:   "tname",
 	ColumnField:      "name",
 	PlaceHolder:      &dialect.PlaceHolderName{Prefix: ":", Format: "v"},
 }

--- a/dialect/oracle/main.go
+++ b/dialect/oracle/main.go
@@ -35,7 +35,7 @@ var oracleSpec = &dialect.Entry{
 	from all_tab_columns
    where table_name = UPPER(:1)
    order by column_id`,
-	SqlForTab:        `select * from tab where tname not like 'BIN$%'`,
+	SQLForTables:     `select * from tab where tname not like 'BIN$%'`,
 	TypeConverterFor: oracleTypeNameToConv,
 	TableField:       "tname",
 	ColumnField:      "name",

--- a/dialect/oracle/main.go
+++ b/dialect/oracle/main.go
@@ -43,5 +43,5 @@ var oracleSpec = &dialect.Entry{
 }
 
 func init() {
-	dialect.Register("ORACLE", oracleSpec)
+	oracleSpec.Register("ORACLE")
 }

--- a/dialect/oracle/main.go
+++ b/dialect/oracle/main.go
@@ -35,11 +35,11 @@ var oracleSpec = &dialect.Entry{
 	from all_tab_columns
    where table_name = UPPER(:1)
    order by column_id`,
-	SqlForTab:      `select * from tab where tname not like 'BIN$%'`,
-	TypeNameToConv: oracleTypeNameToConv,
-	TableField:     "tname",
-	ColumnField:    "name",
-	PlaceHolder:    &dialect.PlaceHolderName{Prefix: ":", Format: "v"},
+	SqlForTab:        `select * from tab where tname not like 'BIN$%'`,
+	TypeConverterFor: oracleTypeNameToConv,
+	TableField:       "tname",
+	ColumnField:      "name",
+	PlaceHolder:      &dialect.PlaceHolderName{Prefix: ":", Format: "v"},
 }
 
 func init() {

--- a/dialect/oracle/main.go
+++ b/dialect/oracle/main.go
@@ -19,7 +19,7 @@ func oracleTypeNameToConv(typeName string) func(string) (any, error) {
 
 var oracleSpec = &dialect.Entry{
 	Usage: "sqlbless oracle://<USERNAME>:<PASSWORD>@<HOSTNAME>:<PORT>/<SERVICE>",
-	SqlForDesc: `
+	SQLForColumns: `
   select column_id as "ID",
 		 column_name as "NAME",
 		 case 

--- a/dialect/postgresql/main.go
+++ b/dialect/postgresql/main.go
@@ -68,7 +68,7 @@ var postgresSpec = &dialect.Entry{
         from information_schema.tables
        where table_type = 'BASE TABLE'
          and table_schema not in ('pg_catalog', 'information_schema')`,
-	TypeNameToConv:      postgresTypeNameToConv,
+	TypeConverterFor:    postgresTypeNameToConv,
 	PlaceHolder:         &placeHolder{},
 	TableField:          "table_name",
 	ColumnField:         "name",

--- a/dialect/postgresql/main.go
+++ b/dialect/postgresql/main.go
@@ -68,12 +68,11 @@ var postgresSpec = &dialect.Entry{
         from information_schema.tables
        where table_type = 'BASE TABLE'
          and table_schema not in ('pg_catalog', 'information_schema')`,
-	DisplayDateTimeLayout: dialect.DateTimeTzLayout,
-	TypeNameToConv:        postgresTypeNameToConv,
-	PlaceHolder:           &placeHolder{},
-	TableField:            "table_name",
-	ColumnField:           "name",
-	CanUseInTransaction:   canUseInTransaction,
+	TypeNameToConv:      postgresTypeNameToConv,
+	PlaceHolder:         &placeHolder{},
+	TableField:          "table_name",
+	ColumnField:         "name",
+	CanUseInTransaction: canUseInTransaction,
 }
 
 func canUseInTransaction(sql string) bool {

--- a/dialect/postgresql/main.go
+++ b/dialect/postgresql/main.go
@@ -70,7 +70,7 @@ var postgresSpec = &dialect.Entry{
          and table_schema not in ('pg_catalog', 'information_schema')`,
 	TypeConverterFor:    postgresTypeNameToConv,
 	PlaceHolder:         &placeHolder{},
-	TableField:          "table_name",
+	TableNameField:      "table_name",
 	ColumnField:         "name",
 	CanUseInTransaction: canUseInTransaction,
 }

--- a/dialect/postgresql/main.go
+++ b/dialect/postgresql/main.go
@@ -68,11 +68,11 @@ var postgresSpec = &dialect.Entry{
         from information_schema.tables
        where table_type = 'BASE TABLE'
          and table_schema not in ('pg_catalog', 'information_schema')`,
-	TypeConverterFor:    postgresTypeNameToConv,
-	PlaceHolder:         &placeHolder{},
-	TableNameField:      "table_name",
-	ColumnNameField:     "name",
-	CanUseInTransaction: canUseInTransaction,
+	TypeConverterFor:  postgresTypeNameToConv,
+	PlaceHolder:       &placeHolder{},
+	TableNameField:    "table_name",
+	ColumnNameField:   "name",
+	IsTransactionSafe: canUseInTransaction,
 }
 
 func canUseInTransaction(sql string) bool {

--- a/dialect/postgresql/main.go
+++ b/dialect/postgresql/main.go
@@ -44,7 +44,7 @@ func (ph *placeHolder) Values() (result []any) {
 
 var postgresSpec = &dialect.Entry{
 	Usage: "sqlbless postgres://<USERNAME>:<PASSWORD>@<HOSTNAME>:<PORT>/<DBNAME>?sslmode=disable",
-	SqlForDesc: `
+	SQLForColumns: `
       select a.attnum as "ID",
              a.attname as "NAME",
              case

--- a/dialect/postgresql/main.go
+++ b/dialect/postgresql/main.go
@@ -63,7 +63,7 @@ var postgresSpec = &dialect.Entry{
          and t.oid = a.atttypid
          and a.attisdropped is false
        order by a.attnum`,
-	SqlForTab: `
+	SQLForTables: `
       select *
         from information_schema.tables
        where table_type = 'BASE TABLE'

--- a/dialect/postgresql/main.go
+++ b/dialect/postgresql/main.go
@@ -90,5 +90,5 @@ func canUseInTransaction(sql string) bool {
 }
 
 func init() {
-	dialect.Register("POSTGRES", postgresSpec)
+	postgresSpec.Register("POSTGRES")
 }

--- a/dialect/postgresql/main.go
+++ b/dialect/postgresql/main.go
@@ -71,7 +71,7 @@ var postgresSpec = &dialect.Entry{
 	TypeConverterFor:    postgresTypeNameToConv,
 	PlaceHolder:         &placeHolder{},
 	TableNameField:      "table_name",
-	ColumnField:         "name",
+	ColumnNameField:     "name",
 	CanUseInTransaction: canUseInTransaction,
 }
 

--- a/dialect/query.go
+++ b/dialect/query.go
@@ -83,6 +83,8 @@ func (e *Entry) FetchTables(ctx context.Context, conn CanQuery) ([]string, error
 	return queryOneColumn(ctx, conn, e.BuildSQLForTables(), e.TableNameField)
 }
 
-func (e *Entry) Columns(ctx context.Context, conn CanQuery, table string) ([]string, error) {
+// Columns executes the SQL to list column names for the specified table.
+// It returns a slice of column names or an error if the query fails.
+func (e *Entry) FetchColumns(ctx context.Context, conn CanQuery, table string) ([]string, error) {
 	return queryOneColumn(ctx, conn, e.BuildSQLForColumns(table), e.ColumnNameField, table)
 }

--- a/dialect/query.go
+++ b/dialect/query.go
@@ -67,7 +67,7 @@ func queryOneColumn(ctx context.Context, conn CanQuery, sqlStr, columnName strin
 }
 
 func (e *Entry) SqlToQueryTables() string {
-	return e.SqlForTab
+	return e.SQLForTables
 }
 
 func (e *Entry) SqlToQueryColumns(table string) string {

--- a/dialect/query.go
+++ b/dialect/query.go
@@ -75,7 +75,7 @@ func (e *Entry) SqlToQueryColumns(table string) string {
 }
 
 func (e *Entry) Tables(ctx context.Context, conn CanQuery) ([]string, error) {
-	return queryOneColumn(ctx, conn, e.SqlToQueryTables(), e.TableField)
+	return queryOneColumn(ctx, conn, e.SqlToQueryTables(), e.TableNameField)
 }
 
 func (e *Entry) Columns(ctx context.Context, conn CanQuery, table string) ([]string, error) {

--- a/dialect/query.go
+++ b/dialect/query.go
@@ -79,5 +79,5 @@ func (e *Entry) Tables(ctx context.Context, conn CanQuery) ([]string, error) {
 }
 
 func (e *Entry) Columns(ctx context.Context, conn CanQuery, table string) ([]string, error) {
-	return queryOneColumn(ctx, conn, e.SqlToQueryColumns(table), e.ColumnField, table)
+	return queryOneColumn(ctx, conn, e.SqlToQueryColumns(table), e.ColumnNameField, table)
 }

--- a/dialect/query.go
+++ b/dialect/query.go
@@ -77,7 +77,9 @@ func (e *Entry) BuildSQLForColumns(table string) string {
 	return strings.ReplaceAll(e.SQLForColumns, "{table_name}", table)
 }
 
-func (e *Entry) Tables(ctx context.Context, conn CanQuery) ([]string, error) {
+// Tables executes the SQL to list all table names defined by the dialect.
+// It returns a slice of table names or an error if the query fails.
+func (e *Entry) FetchTables(ctx context.Context, conn CanQuery) ([]string, error) {
 	return queryOneColumn(ctx, conn, e.BuildSQLForTables(), e.TableNameField)
 }
 

--- a/dialect/query.go
+++ b/dialect/query.go
@@ -71,7 +71,7 @@ func (e *Entry) SqlToQueryTables() string {
 }
 
 func (e *Entry) SqlToQueryColumns(table string) string {
-	return strings.ReplaceAll(e.SqlForDesc, "{table_name}", table)
+	return strings.ReplaceAll(e.SQLForColumns, "{table_name}", table)
 }
 
 func (e *Entry) Tables(ctx context.Context, conn CanQuery) ([]string, error) {

--- a/dialect/query.go
+++ b/dialect/query.go
@@ -70,7 +70,9 @@ func (e *Entry) SqlToQueryTables() string {
 	return e.SQLForTables
 }
 
-func (e *Entry) SqlToQueryColumns(table string) string {
+// BuildSQLForColumns returns the SQL statement used to retrieve the list of columns
+// for the given table name. The placeholder "{table_name}" in the template will be replaced.
+func (e *Entry) BuildSQLForColumns(table string) string {
 	return strings.ReplaceAll(e.SQLForColumns, "{table_name}", table)
 }
 
@@ -79,5 +81,5 @@ func (e *Entry) Tables(ctx context.Context, conn CanQuery) ([]string, error) {
 }
 
 func (e *Entry) Columns(ctx context.Context, conn CanQuery, table string) ([]string, error) {
-	return queryOneColumn(ctx, conn, e.SqlToQueryColumns(table), e.ColumnNameField, table)
+	return queryOneColumn(ctx, conn, e.BuildSQLForColumns(table), e.ColumnNameField, table)
 }

--- a/dialect/query.go
+++ b/dialect/query.go
@@ -66,7 +66,8 @@ func queryOneColumn(ctx context.Context, conn CanQuery, sqlStr, columnName strin
 	}
 }
 
-func (e *Entry) SqlToQueryTables() string {
+// BuildSQLForTables returns the SQL statement used to retrieve the list of tables.
+func (e *Entry) BuildSQLForTables() string {
 	return e.SQLForTables
 }
 
@@ -77,7 +78,7 @@ func (e *Entry) BuildSQLForColumns(table string) string {
 }
 
 func (e *Entry) Tables(ctx context.Context, conn CanQuery) ([]string, error) {
-	return queryOneColumn(ctx, conn, e.SqlToQueryTables(), e.TableNameField)
+	return queryOneColumn(ctx, conn, e.BuildSQLForTables(), e.TableNameField)
 }
 
 func (e *Entry) Columns(ctx context.Context, conn CanQuery, table string) ([]string, error) {

--- a/dialect/sqlite/main.go
+++ b/dialect/sqlite/main.go
@@ -21,7 +21,7 @@ var Entry = &dialect.Entry{
 	union all
 	select 'temp_schema' AS schema,name,rootpage,sql FROM sqlite_temp_schema
 	where type = 'temp_schema'`,
-	TypeNameToConv:      typeNameToConv,
+	TypeConverterFor:    typeNameToConv,
 	PlaceHolder:         &placeHolder{},
 	SqlForDesc:          `PRAGMA table_info({table_name})`,
 	TableField:          "name",

--- a/dialect/sqlite/main.go
+++ b/dialect/sqlite/main.go
@@ -21,12 +21,12 @@ var Entry = &dialect.Entry{
 	union all
 	select 'temp_schema' AS schema,name,rootpage,sql FROM sqlite_temp_schema
 	where type = 'temp_schema'`,
-	TypeConverterFor:    typeNameToConv,
-	PlaceHolder:         &placeHolder{},
-	SQLForColumns:       `PRAGMA table_info({table_name})`,
-	TableNameField:      "name",
-	ColumnNameField:     "name",
-	CanUseInTransaction: canUseInTransaction,
+	TypeConverterFor:  typeNameToConv,
+	PlaceHolder:       &placeHolder{},
+	SQLForColumns:     `PRAGMA table_info({table_name})`,
+	TableNameField:    "name",
+	ColumnNameField:   "name",
+	IsTransactionSafe: canUseInTransaction,
 	IsQuerySQL: func(s string) bool {
 		s, _ = misc.CutField(s)
 		return strings.EqualFold(s, "PRAGMA")

--- a/dialect/sqlite/main.go
+++ b/dialect/sqlite/main.go
@@ -93,5 +93,5 @@ func (ph *placeHolder) Values() (result []any) {
 }
 
 func init() {
-	dialect.Register("SQLITE3", Entry)
+	Entry.Register("SQLITE3")
 }

--- a/dialect/sqlite/main.go
+++ b/dialect/sqlite/main.go
@@ -15,7 +15,7 @@ const dateTimeTzLayout = "2006-01-02 15:04:05.999999999 -07:00"
 
 var Entry = &dialect.Entry{
 	Usage: "sqlbless sqlite3 :memory: OR <FILEPATH>",
-	SqlForTab: `
+	SQLForTables: `
 	select      'master' AS schema,name,rootpage,sql FROM sqlite_master
 	where type = 'table'
 	union all

--- a/dialect/sqlite/main.go
+++ b/dialect/sqlite/main.go
@@ -24,7 +24,7 @@ var Entry = &dialect.Entry{
 	TypeConverterFor:    typeNameToConv,
 	PlaceHolder:         &placeHolder{},
 	SQLForColumns:       `PRAGMA table_info({table_name})`,
-	TableField:          "name",
+	TableNameField:      "name",
 	ColumnField:         "name",
 	CanUseInTransaction: canUseInTransaction,
 	IsQuerySQL: func(s string) bool {

--- a/dialect/sqlite/main.go
+++ b/dialect/sqlite/main.go
@@ -25,7 +25,7 @@ var Entry = &dialect.Entry{
 	PlaceHolder:         &placeHolder{},
 	SQLForColumns:       `PRAGMA table_info({table_name})`,
 	TableNameField:      "name",
-	ColumnField:         "name",
+	ColumnNameField:     "name",
 	CanUseInTransaction: canUseInTransaction,
 	IsQuerySQL: func(s string) bool {
 		s, _ = misc.CutField(s)

--- a/dialect/sqlite/main.go
+++ b/dialect/sqlite/main.go
@@ -21,13 +21,12 @@ var Entry = &dialect.Entry{
 	union all
 	select 'temp_schema' AS schema,name,rootpage,sql FROM sqlite_temp_schema
 	where type = 'temp_schema'`,
-	DisplayDateTimeLayout: dateTimeTzLayout,
-	TypeNameToConv:        typeNameToConv,
-	PlaceHolder:           &placeHolder{},
-	SqlForDesc:            `PRAGMA table_info({table_name})`,
-	TableField:            "name",
-	ColumnField:           "name",
-	CanUseInTransaction:   canUseInTransaction,
+	TypeNameToConv:      typeNameToConv,
+	PlaceHolder:         &placeHolder{},
+	SqlForDesc:          `PRAGMA table_info({table_name})`,
+	TableField:          "name",
+	ColumnField:         "name",
+	CanUseInTransaction: canUseInTransaction,
 	IsQuerySQL: func(s string) bool {
 		s, _ = misc.CutField(s)
 		return strings.EqualFold(s, "PRAGMA")

--- a/dialect/sqlite/main.go
+++ b/dialect/sqlite/main.go
@@ -23,7 +23,7 @@ var Entry = &dialect.Entry{
 	where type = 'temp_schema'`,
 	TypeConverterFor:    typeNameToConv,
 	PlaceHolder:         &placeHolder{},
-	SqlForDesc:          `PRAGMA table_info({table_name})`,
+	SQLForColumns:       `PRAGMA table_info({table_name})`,
 	TableField:          "name",
 	ColumnField:         "name",
 	CanUseInTransaction: canUseInTransaction,

--- a/dialect/sqlserver/main.go
+++ b/dialect/sqlserver/main.go
@@ -42,11 +42,11 @@ var sqlServerSpec = &dialect.Entry{
 	   and o.name = @p1
 	   and c.user_type_id = t.user_type_id
 	 order by c.column_id`,
-	SqlForTab:      `select * from sys.tables`,
-	TypeNameToConv: sqlServerTypeNameToConv,
-	PlaceHolder:    &dialect.PlaceHolderName{Prefix: "@", Format: "v"},
-	TableField:     "name",
-	ColumnField:    "name",
+	SqlForTab:        `select * from sys.tables`,
+	TypeConverterFor: sqlServerTypeNameToConv,
+	PlaceHolder:      &dialect.PlaceHolderName{Prefix: "@", Format: "v"},
+	TableField:       "name",
+	ColumnField:      "name",
 }
 
 func init() {

--- a/dialect/sqlserver/main.go
+++ b/dialect/sqlserver/main.go
@@ -46,7 +46,7 @@ var sqlServerSpec = &dialect.Entry{
 	TypeConverterFor: sqlServerTypeNameToConv,
 	PlaceHolder:      &dialect.PlaceHolderName{Prefix: "@", Format: "v"},
 	TableNameField:   "name",
-	ColumnField:      "name",
+	ColumnNameField:  "name",
 }
 
 func init() {

--- a/dialect/sqlserver/main.go
+++ b/dialect/sqlserver/main.go
@@ -42,7 +42,7 @@ var sqlServerSpec = &dialect.Entry{
 	   and o.name = @p1
 	   and c.user_type_id = t.user_type_id
 	 order by c.column_id`,
-	SqlForTab:        `select * from sys.tables`,
+	SQLForTables:     `select * from sys.tables`,
 	TypeConverterFor: sqlServerTypeNameToConv,
 	PlaceHolder:      &dialect.PlaceHolderName{Prefix: "@", Format: "v"},
 	TableField:       "name",

--- a/dialect/sqlserver/main.go
+++ b/dialect/sqlserver/main.go
@@ -42,12 +42,11 @@ var sqlServerSpec = &dialect.Entry{
 	   and o.name = @p1
 	   and c.user_type_id = t.user_type_id
 	 order by c.column_id`,
-	SqlForTab:             `select * from sys.tables`,
-	DisplayDateTimeLayout: dialect.DateTimeTzLayout,
-	TypeNameToConv:        sqlServerTypeNameToConv,
-	PlaceHolder:           &dialect.PlaceHolderName{Prefix: "@", Format: "v"},
-	TableField:            "name",
-	ColumnField:           "name",
+	SqlForTab:      `select * from sys.tables`,
+	TypeNameToConv: sqlServerTypeNameToConv,
+	PlaceHolder:    &dialect.PlaceHolderName{Prefix: "@", Format: "v"},
+	TableField:     "name",
+	ColumnField:    "name",
 }
 
 func init() {

--- a/dialect/sqlserver/main.go
+++ b/dialect/sqlserver/main.go
@@ -50,5 +50,5 @@ var sqlServerSpec = &dialect.Entry{
 }
 
 func init() {
-	dialect.Register("SQLSERVER", sqlServerSpec)
+	sqlServerSpec.Register("SQLSERVER")
 }

--- a/dialect/sqlserver/main.go
+++ b/dialect/sqlserver/main.go
@@ -45,7 +45,7 @@ var sqlServerSpec = &dialect.Entry{
 	SQLForTables:     `select * from sys.tables`,
 	TypeConverterFor: sqlServerTypeNameToConv,
 	PlaceHolder:      &dialect.PlaceHolderName{Prefix: "@", Format: "v"},
-	TableField:       "name",
+	TableNameField:   "name",
 	ColumnField:      "name",
 }
 

--- a/dialect/sqlserver/main.go
+++ b/dialect/sqlserver/main.go
@@ -22,7 +22,7 @@ func sqlServerTypeNameToConv(typeName string) func(string) (any, error) {
 
 var sqlServerSpec = &dialect.Entry{
 	Usage: "sqlbless sqlserver://@<HOSTNAME>?database=<DBNAME>",
-	SqlForDesc: `
+	SQLForColumns: `
 	select c.column_id as "ID",
 		   c.name as "NAME",
 		   case

--- a/edit.go
+++ b/edit.go
@@ -97,7 +97,7 @@ func doEdit(ctx context.Context, ss *session, command string, pilot commandIn) e
 	// replace `edit ` to `select * from `
 	_, tableAndWhere := misc.CutField(command)
 	if tableAndWhere == "" {
-		tables, err := ss.Dialect.Tables(ctx, ss.conn)
+		tables, err := ss.Dialect.FetchTables(ctx, ss.conn)
 		if err != nil {
 			return err
 		}

--- a/internal/sqlcompletion/main.go
+++ b/internal/sqlcompletion/main.go
@@ -138,7 +138,7 @@ func (C *completeType) columns(ctx context.Context, tables []string) (result []s
 		}
 		values, ok := C.columnCache[tableName]
 		if !ok {
-			values, _ = C.Dialect.Columns(ctx, C.Conn, tableName)
+			values, _ = C.Dialect.FetchColumns(ctx, C.Conn, tableName)
 			C.columnCache[tableName] = values
 		}
 		result = append(result, values...)

--- a/internal/sqlcompletion/main.go
+++ b/internal/sqlcompletion/main.go
@@ -123,7 +123,7 @@ func (C *completeType) getCandidates(ctx context.Context, fields []string) ([]st
 
 func (C *completeType) tables(ctx context.Context) []string {
 	if len(C.tableCache) <= 0 {
-		C.tableCache, _ = C.Dialect.Tables(ctx, C.Conn)
+		C.tableCache, _ = C.Dialect.FetchTables(ctx, C.Conn)
 	}
 	return C.tableCache
 }

--- a/loop.go
+++ b/loop.go
@@ -208,7 +208,7 @@ func (ss *session) Loop(ctx context.Context, commandIn commandIn) error {
 			} else {
 				if ss.tx == nil {
 					_, err = ss.conn.ExecContext(ctx, query)
-				} else if f := ss.Dialect.CanUseInTransaction; f != nil && f(query) {
+				} else if f := ss.Dialect.IsTransactionSafe; f != nil && f(query) {
 					_, err = ss.tx.ExecContext(ctx, query)
 				} else {
 					err = ErrTransactionIsNotClosed

--- a/release_note_en.md
+++ b/release_note_en.md
@@ -1,5 +1,7 @@
 ( **English** / [Japanese](release_note_ja.md) )
 
+- Refactor `dialect` subpackage: rename fields and methods for clarity (#8)
+
 v0.25.0
 =======
 Nov 3, 2025

--- a/release_note_ja.md
+++ b/release_note_ja.md
@@ -1,5 +1,7 @@
 ( [English](release_note_en.md) / **Japanese** )
 
+- サブパッケージ `dialect` をリファクタリング: フィールド・メソッドを改名 (#8)
+
 v0.25.0
 =======
 Nov 3, 2025

--- a/spread/edit.go
+++ b/spread/edit.go
@@ -126,7 +126,7 @@ func (editor *Editor) Edit(ctx context.Context, tableAndWhere string, termOut io
 		name := strings.ToUpper(ct.DatabaseTypeName())
 		var v func(string) (string, error)
 		_ct := ct
-		if conv := editor.TypeToConv(name); conv != nil {
+		if conv := editor.LookupConverter(name); conv != nil {
 			quoteFunc = append(quoteFunc, conv)
 			v = func(s string) (string, error) {
 				if s == editor.Null || s == "" {


### PR DESCRIPTION
- Rename `dialect.Entry.Columns` to `FetchColumns`
- Rename `dialect.Entry.Tables` to `FetchTables`
- Rename `dialect.SqlToQueryTables` to `BuildSQLForTables`
- Rename `dialect.SqlToQueryColumns` to `BuildSQLForColumns`
- Add comments to the field and the method of `dialect.Entry`
- Rename `dialect.Entry.CanUseInTransaction` to `IsTransactionSafe`
- Rename `dialect.Entry.ColumnField` to `ColumnNameField`
- Rename `dialect.Entry.TableField` to `TableNameField`
- Rename `dialect.Entry.SqlForTab` to `SQLForTables`
- Rename `dialect.Entry.SqlForDesc` to SQLForColumns`
- Rename `dialect.Entry.TypeToConv` to `LookupConverter`
- Rename `dialect.Entry.TypeNameToConv` to `TypeConverterFor`
- Replace the function `dialect.Register` to the method `dialect.(*Entry) Register`
- Removed unused field: `dialect.Entry.DisplayDateTimeLayout`