### PR TITLE
Updated `go-readline-ny` to v1.12.2 and `go-ttyadapter` to v0.2.0, and switched API calls to use `go-ttyadapter`.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/mattn/go-colorable v0.1.14
 	github.com/microsoft/go-mssqldb v1.7.2
 	github.com/nyaosorg/go-box/v3 v3.0.0
-	github.com/nyaosorg/go-readline-ny v1.12.1
+	github.com/nyaosorg/go-readline-ny v1.12.2
 	github.com/sijms/go-ora/v2 v2.8.22
 	golang.org/x/term v0.29.0
 )

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/mattn/go-tty v0.0.7 // indirect
 	github.com/ncruces/go-strftime v0.1.9 // indirect
 	github.com/nyaosorg/go-readline-skk v0.6.0 // indirect
-	github.com/nyaosorg/go-ttyadapter v0.0.1 // indirect
+	github.com/nyaosorg/go-ttyadapter v0.2.0 // indirect
 	github.com/nyaosorg/go-windows-mbcs v0.4.4 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	golang.org/x/crypto v0.29.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdh
 github.com/ncruces/go-strftime v0.1.9/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/nyaosorg/go-box/v3 v3.0.0 h1:W5qfScEkKBoD68gbP/lwfWlvcTRB0rwXkhL+9iC62xI=
 github.com/nyaosorg/go-box/v3 v3.0.0/go.mod h1:70GsE9mIh7JKVCxt71q3jEijO6C9YJmOZqWpPa9w+GY=
-github.com/nyaosorg/go-readline-ny v1.12.1 h1:yEDbW3Np7a/mCKwww3cTQYc9c7U6OnPogMeAjXYUg5M=
-github.com/nyaosorg/go-readline-ny v1.12.1/go.mod h1:JgZg/fWrTrLe+0Pzc7LzptNK28YO6wrdVQPSmJF69ug=
+github.com/nyaosorg/go-readline-ny v1.12.2 h1:PH273rRJ7USE2nCjJK7QzuiFpxJsnzWY2XKsJIdwLSs=
+github.com/nyaosorg/go-readline-ny v1.12.2/go.mod h1:KIoNjr6f6aur67nnYkVvLapZQiFPNRSqUcTe32IgeLE=
 github.com/nyaosorg/go-readline-skk v0.6.0 h1:n7iy806v34+HwiCgBog7OfUaHe9m43z2o6mg3dylgXo=
 github.com/nyaosorg/go-readline-skk v0.6.0/go.mod h1:ulYKxU1enVwOlLA8LFNaRUxSlI1PyayTM1PBOPVs1w8=
 github.com/nyaosorg/go-ttyadapter v0.2.0 h1:2DEL0MeesXRzuppCUlZIwY4vUKTjfIL+8aoR+pUUzGg=

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/nyaosorg/go-readline-ny v1.12.1 h1:yEDbW3Np7a/mCKwww3cTQYc9c7U6OnPogM
 github.com/nyaosorg/go-readline-ny v1.12.1/go.mod h1:JgZg/fWrTrLe+0Pzc7LzptNK28YO6wrdVQPSmJF69ug=
 github.com/nyaosorg/go-readline-skk v0.6.0 h1:n7iy806v34+HwiCgBog7OfUaHe9m43z2o6mg3dylgXo=
 github.com/nyaosorg/go-readline-skk v0.6.0/go.mod h1:ulYKxU1enVwOlLA8LFNaRUxSlI1PyayTM1PBOPVs1w8=
-github.com/nyaosorg/go-ttyadapter v0.0.1 h1:4VslnofOrGLqXvVeKwz51BDR+Q82D2Iitk51urYRLGo=
-github.com/nyaosorg/go-ttyadapter v0.0.1/go.mod h1:w6ySb/Y8rpr0uIju4vN/TMRHC/6ayabORHmEVs6d/qE=
+github.com/nyaosorg/go-ttyadapter v0.2.0 h1:2DEL0MeesXRzuppCUlZIwY4vUKTjfIL+8aoR+pUUzGg=
+github.com/nyaosorg/go-ttyadapter v0.2.0/go.mod h1:w6ySb/Y8rpr0uIju4vN/TMRHC/6ayabORHmEVs6d/qE=
 github.com/nyaosorg/go-windows-mbcs v0.4.4 h1:x5MqDvOsfRO8F2a9Uedlm3I6SB/H0whN4KZknTOLe3w=
 github.com/nyaosorg/go-windows-mbcs v0.4.4/go.mod h1:P610Wyc6LcgDbx2VZhwUQn02XRuwjqGK2l/3wox3auA=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=

--- a/interactive.go
+++ b/interactive.go
@@ -7,8 +7,10 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/nyaosorg/go-ttyadapter"
 	"github.com/nyaosorg/go-ttyadapter/auto"
 	"github.com/nyaosorg/go-ttyadapter/tty8"
+
 	"github.com/nyaosorg/go-readline-ny"
 	"github.com/nyaosorg/go-readline-ny/keys"
 
@@ -71,7 +73,7 @@ func isOneLineCommand(cmdLine string) bool {
 
 type interactiveIn struct {
 	*multiline.Editor
-	tty       readline.ITty
+	tty       ttyadapter.Tty
 	csviPilot csvi.Pilot
 }
 
@@ -131,7 +133,7 @@ func (ss *session) newInteractiveIn() *interactiveIn {
 	if ss.SubmitByEnter {
 		editor.SwapEnter()
 	}
-	var tty readline.ITty
+	var tty ttyadapter.Tty
 	var csviPilot csvi.Pilot
 	if ss.Auto != "" {
 		text := strings.ReplaceAll(ss.Auto, "||", "\n") // "||" -> Ctrl-J(Commit)

--- a/interactive.go
+++ b/interactive.go
@@ -7,10 +7,10 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/nyaosorg/go-ttyadapter/tty8"
 	"github.com/nyaosorg/go-readline-ny"
 	"github.com/nyaosorg/go-readline-ny/auto"
 	"github.com/nyaosorg/go-readline-ny/keys"
-	"github.com/nyaosorg/go-readline-ny/tty8"
 
 	"github.com/hymkor/csvi"
 	"github.com/hymkor/go-multiline-ny"

--- a/interactive.go
+++ b/interactive.go
@@ -7,9 +7,9 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/nyaosorg/go-ttyadapter/auto"
 	"github.com/nyaosorg/go-ttyadapter/tty8"
 	"github.com/nyaosorg/go-readline-ny"
-	"github.com/nyaosorg/go-readline-ny/auto"
 	"github.com/nyaosorg/go-readline-ny/keys"
 
 	"github.com/hymkor/csvi"

--- a/release_note_en.md
+++ b/release_note_en.md
@@ -1,6 +1,7 @@
 ( **English** / [Japanese](release_note_ja.md) )
 
 - Refactor `dialect` subpackage: rename fields and methods for clarity (#8)
+- Updated `go-readline-ny` to v1.12.2 and `go-ttyadapter` to v0.2.0, and switched API calls to use `go-ttyadapter`.(#9)
 
 v0.25.0
 =======

--- a/release_note_ja.md
+++ b/release_note_ja.md
@@ -1,6 +1,7 @@
 ( [English](release_note_en.md) / **Japanese** )
 
 - サブパッケージ `dialect` をリファクタリング: フィールド・メソッドを改名 (#8)
+- `go-readline-ny` を v1.12.2、`go-ttyadapter` を v0.2.0 に更新し、対応する API 呼び出しを `go-ttyadapter` 側に切り替えた。(#9)
 
 v0.25.0
 =======


### PR DESCRIPTION
## (English)

- Updated `go-readline-ny` to v1.12.2 and `go-ttyadapter` to v0.2.0, and switched API calls to use `go-ttyadapter`.

## (Japanese)

- `go-readline-ny` を v1.12.2、`go-ttyadapter` を v0.2.0 に更新し、対応する API 呼び出しを `go-ttyadapter` 側に切り替えた。