### PR TITLE
Fix: go vet: github.com/hymkor/sqlbless/internal/misc.AutoCsvi  struct literal uses unkeyed fields

### DIFF
--- a/edit.go
+++ b/edit.go
@@ -87,7 +87,7 @@ func doEdit(ctx context.Context, ss *session, command string, pilot commandIn) e
 		Exec:  (&askSqlAndExecute{getKey: pilot.GetKey, session: ss}).Exec,
 	}
 	if a, ok := pilot.AutoPilotForCsvi(); ok {
-		editor.Pilot = misc.AutoCsvi{a}
+		editor.Pilot = misc.AutoCsvi{GetKeyAndSize: a}
 	}
 	if ss.tx == nil {
 		editor.Query = ss.conn.QueryContext

--- a/interactive.go
+++ b/interactive.go
@@ -146,7 +146,7 @@ func (ss *session) newInteractiveIn() *interactiveIn {
 		}
 		editor.LineEditor.Tty = tty1
 		tty = tty1
-		csviPilot = misc.AutoCsvi{tty1}
+		csviPilot = misc.AutoCsvi{GetKeyAndSize: tty1}
 	} else {
 		tty = &tty8.Tty{}
 	}


### PR DESCRIPTION
- Fix: go vet: edit.go:90:18: github.com/hymkor/sqlbless/internal/misc.AutoCsvi struct literal uses unkeyed fields
- Fix: go vet: interactive.go:149:15: github.com/hymkor/sqlbless/internal/misc.AutoCsvi struct literal uses unkeyed fields