### PR TITLE
Support `SAVE TRANSACTION` as a TCL command

### DIFF
--- a/interactive.go
+++ b/interactive.go
@@ -121,7 +121,7 @@ func (ss *session) newInteractiveIn() *interactiveIn {
 		editor.ResetColor = "\x1B[0m"
 		editor.DefaultColor = "\x1B[39;49;1m"
 		editor.Highlight = []readline.Highlight{
-			{Pattern: newReservedWordPattern("HOST", "ALTER", "COMMIT", "CREATE", "DELETE", "DESC", "DROP", "EXIT", "HISTORY", "INSERT", "QUIT", "REM", "ROLLBACK", "SELECT", "SPOOL", "START", "TRUNCATE", "UPDATE", "AND", "FROM", "INTO", "OR", "WHERE", "SAVEPOINT", "TO", "TRANSACTION"), Sequence: "\x1B[36;49;1m"},
+			{Pattern: newReservedWordPattern("HOST", "ALTER", "COMMIT", "CREATE", "DELETE", "DESC", "DROP", "EXIT", "HISTORY", "INSERT", "QUIT", "REM", "ROLLBACK", "SELECT", "SPOOL", "START", "TRUNCATE", "UPDATE", "AND", "FROM", "INTO", "OR", "WHERE", "SAVEPOINT", "TO", "SAVE", "TRANSACTION"), Sequence: "\x1B[36;49;1m"},
 			{Pattern: regexp.MustCompile(`[0-9]+`), Sequence: "\x1B[35;49;1m"},
 			{Pattern: regexp.MustCompile(`/\*.*?\*/`), Sequence: "\x1B[33;49;22m"},
 			{Pattern: regexp.MustCompile(`"[^"]*"|"[^"]*$`), Sequence: "\x1B[31;49;1m"},

--- a/internal/sqlcompletion/main.go
+++ b/internal/sqlcompletion/main.go
@@ -30,6 +30,7 @@ func getSqlCommands() []string {
 		"quit",
 		"rem",
 		"rollback",
+		"save",
 		"savepoint",
 		"select",
 		"spool",
@@ -115,6 +116,13 @@ func (C *completeType) getCandidates(ctx context.Context, fields []string) ([]st
 			nextKeyword = nil
 			candidates = func() []string {
 				return []string{"to", "transaction"}
+			}
+		} else if strings.EqualFold(word, "save") {
+			tableListNow = false
+			lastKeywordAt = i
+			nextKeyword = nil
+			candidates = func() []string {
+				return []string{"transaction"}
 			}
 		} else {
 			if tableListNow && i < len(fields)-1 {

--- a/loop.go
+++ b/loop.go
@@ -172,7 +172,7 @@ func (ss *session) Loop(ctx context.Context, commandIn commandIn) error {
 			} else {
 				err = ErrInvalidRollback
 			}
-		case "SAVEPOINT":
+		case "SAVEPOINT", "SAVE":
 			misc.Echo(ss.spool, query)
 			doTCL(ctx, ss, query)
 		case "DELETE", "INSERT", "UPDATE", "MERGE":

--- a/release_note_en.md
+++ b/release_note_en.md
@@ -3,6 +3,7 @@
 - Refactor `dialect` subpackage: rename fields and methods for clarity (#8)
 - Updated `go-readline-ny` to v1.12.2 and `go-ttyadapter` to v0.2.0, and switched API calls to use `go-ttyadapter`.(#9)
 - Support `SAVEPOINT` as a TCL command (#11)
+- Support `SAVE TRANSACTION` as a TCL command (#14)
 - Support `ROLLBACK TO` (or `ROLLBACK TRANSACTION`) as a TCL command (#11)
 - Require `;` after `ROLLBACK` to prevent accidental execution (#11)
 - Fix: Correct handling of `io.EOF` during script execution (#12)

--- a/release_note_ja.md
+++ b/release_note_ja.md
@@ -3,6 +3,7 @@
 - サブパッケージ `dialect` をリファクタリング: フィールド・メソッドを改名 (#8)
 - `go-readline-ny` を v1.12.2、`go-ttyadapter` を v0.2.0 に更新し、対応する API 呼び出しを `go-ttyadapter` 側に切り替えた。(#9)
 - `SAVEPOINT` を TCL コマンドとしてサポート (#11)
+- `SAVE TRANSACTION` を TCL コマンドとしてサポート (#14)
 - `ROLLBACK TO`（もしくは `ROLLBACK TRANSACTION`）を TCL コマンドとしてサポート (#11)
 - 誤操作による実行を防ぐため、`ROLLBACK` には `;` を必須とした (#11)
 * スクリプト中の `SELECT` で起動した `CSVI` は、`>`, `q`, `y` の操作で自動的に終了するようにした。 (#12)


### PR DESCRIPTION
## English

- This is equivalent to `SAVEPOINT` in other databases, but it was previously unsupported.

## Japanese

* 他の DB でいうところの `SAVEPOINT` コマンドと等価ですが、サポートされていませんでした。