### PR TITLE
Enable `RELEASE SAVEPOINT` to execute within a transaction

### DIFF
--- a/loop.go
+++ b/loop.go
@@ -174,7 +174,7 @@ func (ss *session) Loop(ctx context.Context, commandIn commandIn) error {
 			}
 		case "SAVEPOINT", "SAVE":
 			misc.Echo(ss.spool, query)
-			doTCL(ctx, ss, query)
+			err = doTCL(ctx, ss, query)
 		case "DELETE", "INSERT", "UPDATE", "MERGE":
 			misc.Echo(ss.spool, query)
 			isNewTx := (ss.tx == nil)

--- a/loop.go
+++ b/loop.go
@@ -172,7 +172,7 @@ func (ss *session) Loop(ctx context.Context, commandIn commandIn) error {
 			} else {
 				err = ErrInvalidRollback
 			}
-		case "SAVEPOINT", "SAVE":
+		case "SAVEPOINT", "SAVE", "RELEASE":
 			misc.Echo(ss.spool, query)
 			err = doTCL(ctx, ss, query)
 		case "DELETE", "INSERT", "UPDATE", "MERGE":

--- a/release_note_en.md
+++ b/release_note_en.md
@@ -1,5 +1,13 @@
 ( **English** / [Japanese](release_note_ja.md) )
 
+### Bug fixes
+
+- Fix: Errors were not reported during execution of `SAVEPOINT` and `SAVE TRANSACTION`. (#19)
+
+### Specification Changes
+
+- Enable `RELEASE SAVEPOINT` to execute within a transaction. (#19)
+
 v0.26.0
 =======
 Nov 11, 2025

--- a/release_note_ja.md
+++ b/release_note_ja.md
@@ -1,5 +1,13 @@
 ( [English](release_note_en.md) / **Japanese** )
 
+### 不具合修正
+
+- `SAVEPOINT`, `SAVE TRANSACTION` の実行中にエラーが発生してもメッセージが表示されなかった問題を修正 (#19)
+
+### 仕様変更
+
+- `RELEASE SAVEPOINT` もトランザクション内で実行できるようにした。(#19)
+
 v0.26.0
 =======
 Nov 11, 2025


### PR DESCRIPTION
### English

- Fix: Errors were not reported during execution of `SAVEPOINT` and `SAVE TRANSACTION`.
- Enable `RELEASE SAVEPOINT` to execute within a transaction

### Japanese 

- `SAVEPOINT`, `SAVE TRANSACTION` の実行中にエラーが発生してもメッセージが表示されなかった問題を修正
- `RELEASE SAVEPOINT` もトランザクション内で実行できるようにした。