### PR TITLE
Update Csvi library package to v1.20.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/glebarez/go-sqlite v1.22.0
 	github.com/go-sql-driver/mysql v1.8.1
-	github.com/hymkor/csvi v1.19.1
+	github.com/hymkor/csvi v1.20.1
 	github.com/hymkor/go-multiline-ny v0.22.3
 	github.com/hymkor/go-shellcommand v0.0.2
 	github.com/hymkor/struct2flag v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/golang-sql/sqlexp v0.1.0/go.mod h1:J4ad9Vo8ZCWQ2GMrC4UCQy1JpCbwU9m3EO
 github.com/google/pprof v0.0.0-20240409012703-83162a5b38cd h1:gbpYu9NMq8jhDVbvlGkMFWCjLFlqqEZjEmObmhUy6Vo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/hymkor/csvi v1.19.1 h1:gVoqVBgPyEjPWwz3URGLZhQ5RUZQdTzbO5h8sQ0g29g=
-github.com/hymkor/csvi v1.19.1/go.mod h1:s1gvb3w9tVJjb+RhNPGZgHrV8xfRWTIopa57nZCS3hM=
+github.com/hymkor/csvi v1.20.1 h1:C2hL6Y9i57P9K83t3LSfiYYvJK61RlfJ/WKgwTWVjEs=
+github.com/hymkor/csvi v1.20.1/go.mod h1:s1gvb3w9tVJjb+RhNPGZgHrV8xfRWTIopa57nZCS3hM=
 github.com/hymkor/go-multiline-ny v0.22.3 h1:+4ttpG8MQK6F3uWqxbWFoDlIAN8bv4BmH7HyxTIfHn0=
 github.com/hymkor/go-multiline-ny v0.22.3/go.mod h1:9FsFQa3nIhxAjz1yL0kK/Oya/LB4fBsHckY3ZqBcTJY=
 github.com/hymkor/go-shellcommand v0.0.2 h1:6+XG2h/9DGk5i3Oh4rU48z/nsPWx4Sp73s6OpryQtyw=

--- a/release_note_en.md
+++ b/release_note_en.md
@@ -2,6 +2,11 @@ Release notes (English)
 =======================
 ( **English** / [Japanese](release_note_ja.md) )
 
+- Update github.com/hymkor/csvi from v1.19.1 to v1.20.1 (#27)
+  - Use `(*csvi.Application) MessageAndGetKey` instead of removed `(*csvi.Application) YesNo`
+  - Fix display overflow caused by halfwidth kana with voiced/semi-voiced sound marks
+  - Fix a CPU spinning issue after data fetching completed
+
 v0.27.1
 -------
 Jan 4, 2026

--- a/release_note_ja.md
+++ b/release_note_ja.md
@@ -2,6 +2,11 @@ Release notes (Japanese)
 ========================
 ( [English](release_note_en.md) / **Japanese** )
 
+- Update github.com/hymkor/csvi from v1.19.1 to v1.20.1 (#27)
+  - 廃止された `(*csvi.Application) YesNo` のかわりに、`(*csvi.Application) MessageAndGetKey` を使うようにした
+  - 半角カナの濁音・半濁音記号が含まれていると表示桁数が超過して表示が乱れる問題を修正
+  - データ読み込みが終わると、CPU が空回りになる問題に対処
+
 v0.27.1
 -------
 Jan 4, 2026

--- a/spread/view.go
+++ b/spread/view.go
@@ -93,7 +93,8 @@ func (viewer *Viewer) edit(title string, validate func(*csvi.CellValidatedEvent)
 	}
 
 	apply := func(app *csvi.KeyEventArgs) (*csvi.CommandResult, error) {
-		if app.YesNo("Apply changes and quit ? [y/n] ") {
+		ch, err := app.MessageAndGetKey("Apply changes and quit ? [y/n] ")
+		if err == nil && (ch == "y" || ch == "Y") {
 			io.WriteString(app, "y\n")
 			applyChange = true
 			return &csvi.CommandResult{Quit: true}, nil


### PR DESCRIPTION
(English)
- Update github.com/hymkor/csvi from v1.19.1 to v1.20.1
  - Use `(*csvi.Application) MessageAndGetKey` instead of removed `(*csvi.Application) YesNo`
  - Fix display overflow caused by halfwidth kana with voiced/semi-voiced sound marks
  - Fix a CPU spinning issue after data fetching completed

(Japanese)
- Update github.com/hymkor/csvi from v1.19.1 to v1.20.1
  - 廃止された `(*csvi.Application) YesNo` のかわりに、`(*csvi.Application) MessageAndGetKey` を使うようにした
  - 半角カナの濁音・半濁音記号が含まれていると表示桁数が超過して表示が乱れる問題を修正
  - データ読み込みが終わると、CPU が空回りになる問題に対処
