### PR TITLE
Stop using deprecated fields: `csvi.KeyEventArgs.CursorRow` and `CursorCol`

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -119,13 +119,13 @@ func doDescTables(ctx context.Context, ss *session, commandIn commandIn) error {
 	var name string
 
 	handler := func(e *csvi.KeyEventArgs) (*csvi.CommandResult, error) {
-		if e.CursorRow.Index() == 0 {
+		if e.CurrentRow().Index() == 0 {
 			return &csvi.CommandResult{}, nil
 		}
 		header := e.Front()
 		for i, c := range header.Cell {
 			if strings.EqualFold(c.Text(), ss.Dialect.TableNameField) {
-				name = e.CursorRow.Cell[i].Text()
+				name = e.CurrentRow().Cell[i].Text()
 				return &csvi.CommandResult{Quit: true}, nil
 			}
 		}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/glebarez/go-sqlite v1.22.0
 	github.com/go-sql-driver/mysql v1.8.1
-	github.com/hymkor/csvi v1.21.1
+	github.com/hymkor/csvi v1.21.3-0.20260208161734-1e6bcc5731ad
 	github.com/hymkor/go-multiline-ny v0.22.4
 	github.com/hymkor/go-shellcommand v0.0.2
 	github.com/hymkor/struct2flag v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/golang-sql/sqlexp v0.1.0/go.mod h1:J4ad9Vo8ZCWQ2GMrC4UCQy1JpCbwU9m3EO
 github.com/google/pprof v0.0.0-20240409012703-83162a5b38cd h1:gbpYu9NMq8jhDVbvlGkMFWCjLFlqqEZjEmObmhUy6Vo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/hymkor/csvi v1.21.1 h1:8rgQgH0mGTeuzabk7cN53g87LwoR/uMQIAmIEqIk0bo=
-github.com/hymkor/csvi v1.21.1/go.mod h1:zm4EcSzlGiiCtPWq77a+L3Q5IpJufIEX0q4iIGKXZhs=
+github.com/hymkor/csvi v1.21.3-0.20260208161734-1e6bcc5731ad h1:2b9yxzh3XErM2CNnsffNZavYBgE+tXuU5MMaP3g8Lss=
+github.com/hymkor/csvi v1.21.3-0.20260208161734-1e6bcc5731ad/go.mod h1:zm4EcSzlGiiCtPWq77a+L3Q5IpJufIEX0q4iIGKXZhs=
 github.com/hymkor/go-multiline-ny v0.22.4 h1:Ag2rkBpDnr3jp+AHe1CuXSOQ4AQ8D0+gBNVf+BAX+/0=
 github.com/hymkor/go-multiline-ny v0.22.4/go.mod h1:v2lqQooHVAO53WICAIbgTn74bQtzsg4tFn29d+7JPwY=
 github.com/hymkor/go-shellcommand v0.0.2 h1:6+XG2h/9DGk5i3Oh4rU48z/nsPWx4Sp73s6OpryQtyw=

--- a/release_note_en.md
+++ b/release_note_en.md
@@ -5,8 +5,10 @@ Release notes (English)
 - `edit` statement: Restore row deletion commands (`dd`, `dr`):  
   Fixed a keybinding conflict that rendered row deletion unavailable. The `d` key has been unassigned from the "Set Null" function to restore the `dd` and `dr` commands, following specification changes in Csvi. Field Null assignment remains available via the `x` key. (#35)
 - `edit` statement: Prevent creation of empty lines at the end of the editable CSV content. ([csvi#79])
+- (internal changes) Stop using deprecated fields: `csvi.KeyEventArgs.CursorRow` and `CursorCol` ([csvi#80],#38)
 
 [csvi#79]: https://github.com/hymkor/csvi/pull/79
+[csvi#80]: https://github.com/hymkor/csvi/pull/80
 
 v0.27.3
 -------

--- a/release_note_ja.md
+++ b/release_note_ja.md
@@ -5,8 +5,10 @@ Release notes (Japanese)
 - `edit`文: 行削除コマンド（`dd`, `dr`）の復旧  
   レコードの削除操作（`dd`, `dr`）を再び利用可能にした。以前のバージョンでは、Null設定機能を `d` キーにも割り当てていたため、Csvi側の仕様変更（`D` の廃止）に伴い、行削除が実行できない状態になっていた。今回、`d` へのNull設定機能を解除することでこの競合を解消した。※Null設定機能は、引き続き `x` キーで利用可能。 (#35)
 - `edit`文: 編集対象の CSV データ末尾に空行が生成されないようにした。([csvi#79])
+- (内部修正) 廃止予定のフィールド `csvi.KeyEventArgs.CursorRow` と `CursorCol` 使わないようにした ([csvi#80],#38)
 
 [csvi#79]: https://github.com/hymkor/csvi/pull/79
+[csvi#80]: https://github.com/hymkor/csvi/pull/80
 
 v0.27.3
 -------

--- a/spread/view.go
+++ b/spread/view.go
@@ -59,18 +59,18 @@ func (viewer *Viewer) edit(title string, validate func(*csvi.CellValidatedEvent)
 
 	applyChange := false
 	setNull := func(e *csvi.KeyEventArgs) (*csvi.CommandResult, error) {
-		if e.CursorRow.Index() < viewer.HeaderLines {
+		if e.CurrentRow().Index() < viewer.HeaderLines {
 			return &csvi.CommandResult{}, nil
 		}
 		ce := &csvi.CellValidatedEvent{
 			Text: viewer.Null,
-			Row:  e.CursorRow.Index(),
-			Col:  e.CursorCol,
+			Row:  e.CurrentRow().Index(),
+			Col:  e.CurrentCol(),
 		}
 		if _, err := validate(ce); err != nil {
 			return &csvi.CommandResult{Message: err.Error()}, nil
 		}
-		e.CursorRow.Replace(e.CursorCol, viewer.Null, &uncsv.Mode{Comma: viewer.Comma})
+		e.CurrentRow().Replace(e.CurrentCol(), viewer.Null, &uncsv.Mode{Comma: viewer.Comma})
 		return &csvi.CommandResult{}, nil
 	}
 


### PR DESCRIPTION
(English)
- Stop using deprecated fields: `csvi.KeyEventArgs.CursorRow` and `CursorCol` ([csvi#80])

(Japanese)
- 廃止予定のフィールド `csvi.KeyEventArgs.CursorRow` と `CursorCol` 使わないようにした ([csvi#80])

[csvi#80]: https://github.com/hymkor/csvi/pull/80