### PR TITLE
`edit` statement: Quit immediately on `q` without a prompt if there are no changes

### DIFF
--- a/release_note_en.md
+++ b/release_note_en.md
@@ -6,9 +6,11 @@ Release notes (English)
   Fixed a keybinding conflict that rendered row deletion unavailable. The `d` key has been unassigned from the "Set Null" function to restore the `dd` and `dr` commands, following specification changes in Csvi. Field Null assignment remains available via the `x` key. (#35)
 - `edit` statement: Prevent creation of empty lines at the end of the editable CSV content. ([csvi#79])
 - (internal changes) Stop using deprecated fields: `csvi.KeyEventArgs.CursorRow` and `CursorCol` ([csvi#80],#38)
+- `edit` statement: Quit immediately on `q` without a prompt if there are no changes.([csvi#81],#39)
 
 [csvi#79]: https://github.com/hymkor/csvi/pull/79
 [csvi#80]: https://github.com/hymkor/csvi/pull/80
+[csvi#81]: https://github.com/hymkor/csvi/pull/81
 
 v0.27.3
 -------

--- a/release_note_ja.md
+++ b/release_note_ja.md
@@ -6,9 +6,11 @@ Release notes (Japanese)
   レコードの削除操作（`dd`, `dr`）を再び利用可能にした。以前のバージョンでは、Null設定機能を `d` キーにも割り当てていたため、Csvi側の仕様変更（`D` の廃止）に伴い、行削除が実行できない状態になっていた。今回、`d` へのNull設定機能を解除することでこの競合を解消した。※Null設定機能は、引き続き `x` キーで利用可能。 (#35)
 - `edit`文: 編集対象の CSV データ末尾に空行が生成されないようにした。([csvi#79])
 - (内部修正) 廃止予定のフィールド `csvi.KeyEventArgs.CursorRow` と `CursorCol` 使わないようにした ([csvi#80],#38)
+- `edit`文: 変更がない場合は `q` で確認なしに終了するようにした。([csvi#81],#39)
 
 [csvi#79]: https://github.com/hymkor/csvi/pull/79
 [csvi#80]: https://github.com/hymkor/csvi/pull/80
+[csvi#81]: https://github.com/hymkor/csvi/pull/81
 
 v0.27.3
 -------

--- a/spread/view.go
+++ b/spread/view.go
@@ -75,6 +75,11 @@ func (viewer *Viewer) edit(title string, validate func(*csvi.CellValidatedEvent)
 	}
 
 	quit := func(app *csvi.KeyEventArgs) (*csvi.CommandResult, error) {
+		if !app.IsDirty() {
+			io.WriteString(app, "\n")
+			return &csvi.CommandResult{Quit: true}, nil
+		}
+
 		ch, err := app.MessageAndGetKey(`"Y": Save&Exit  "N": Discard&Exit  <ESC>: Cancel(edit)`)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
(English)
- `edit` statement: Quit immediately on `q` without a prompt if there are no changes.([csvi#81])

(Japanese)
- `edit`文: 変更がない場合は `q` で確認なしに終了するようにした。([csvi#81])

[csvi#81]: https://github.com/hymkor/csvi/pull/81