### PR TITLE
Improve Makefile and README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,4 +51,8 @@ docs:
 	go run github.com/hymkor/minipage@latest -outline-in-sidebar -readme-to-index README.md    > docs/index.html
 	go run github.com/hymkor/minipage@latest -outline-in-sidebar -readme-to-index README_ja.md > docs/index_ja.html
 
+readme:
+	go run github.com/hymkor/example-into-readme@latest
+	go run github.com/hymkor/example-into-readme@latest -target README_ja.md
+
 .PHONY: all test dist _dist clean manifest release docs

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ manifest:
 	make-scoop-manifest *-windows-*.zip > $(NAME).json
 
 release:
-	pwsh -Command "latest-notes.ps1" | gh release create -d --notes-file - -t $(VERSION) $(VERSION) $(wildcard $(NAME)-$(VERSION)-*.zip)
+	$(GO) run github.com/hymkor/latest-notes@master | gh release create -d --notes-file - -t $(VERSION) $(VERSION) $(wildcard $(NAME)-$(VERSION)-*.zip)
 
 get:
 	$(GO) get -u

--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,10 @@ clean:
 	$(DEL) *.zip $(NAME)$(EXE)
 
 manifest:
-	make-scoop-manifest *-windows-*.zip > $(NAME).json
+	$(GO) run github.com/hymkor/make-scoop-manifest@master -all *-windows-*.zip > $(NAME).json
 
 release:
-	$(GO) run github.com/hymkor/latest-notes@master | gh release create -d --notes-file - -t $(VERSION) $(VERSION) $(wildcard $(NAME)-$(VERSION)-*.zip)
+	$(GO) run github.com/hymkor/latest-notes@latest | gh release create -d --notes-file - -t $(VERSION) $(VERSION) $(wildcard $(NAME)-$(VERSION)-*.zip)
 
 docs:
 	minipage -outline-in-sidebar -readme-to-index README.md    > docs/index.html

--- a/Makefile
+++ b/Makefile
@@ -21,15 +21,15 @@ VERSION:=$(shell git describe --tags 2>$(NUL) || echo v0.0.0)
 GOOPT:=-ldflags "-s -w -X github.com/hymkor/sqlbless.Version=$(VERSION)"
 EXE=$(shell $(GO) env GOEXE)
 
-all:
+build:
 	$(GO) fmt ./...
-	$(SET) "CGO_ENABLED=0" && $(GO) build $(GOOPT) && $(GO) build -C "$(CURDIR)/cmd/sqlbless" -o "$(CURDIR)/$(NAME)$(EXE)" $(GOOPT)
+	$(SET) "CGO_ENABLED=0" && $(GO) build -C "$(CURDIR)/cmd/sqlbless" -o "$(CURDIR)" $(GOOPT)
 
 test:
 	$(GO) test -v ./...
 
 _dist:
-	$(MAKE) all
+	$(SET) "CGO_ENABLED=0" && $(GO) build -C "$(CURDIR)/cmd/sqlbless" -o "$(CURDIR)" $(GOOPT)
 	zip -9 $(NAME)-$(VERSION)-$(GOOS)-$(GOARCH).zip $(NAME)$(EXE)
 
 dist:

--- a/Makefile
+++ b/Makefile
@@ -47,15 +47,6 @@ manifest:
 release:
 	$(GO) run github.com/hymkor/latest-notes@master | gh release create -d --notes-file - -t $(VERSION) $(VERSION) $(wildcard $(NAME)-$(VERSION)-*.zip)
 
-get:
-	$(GO) get -u
-	$(GO) get golang.org/x/sys@v0.30.0
-#	$(GO) get golang.org/x/text@v0.22.0
-	$(GO) get golang.org/x/term@v0.29.0 
-	$(GO) get golang.org/x/exp@v0.0.0-20240531132922-fd00a4e0eefc
-	$(GO) mod tidy
-# cd "$(CURDIR)/cmd/sqlbless" && $(GO) get -u && $(GO) mod tidy
-
 docs:
 	minipage -outline-in-sidebar -readme-to-index README.md    > docs/index.html
 	minipage -outline-in-sidebar -readme-to-index README_ja.md > docs/index_ja.html

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ release:
 	$(GO) run github.com/hymkor/latest-notes@latest | gh release create -d --notes-file - -t $(VERSION) $(VERSION) $(wildcard $(NAME)-$(VERSION)-*.zip)
 
 docs:
-	minipage -outline-in-sidebar -readme-to-index README.md    > docs/index.html
-	minipage -outline-in-sidebar -readme-to-index README_ja.md > docs/index_ja.html
+	go run github.com/hymkor/minipage@latest -outline-in-sidebar -readme-to-index README.md    > docs/index.html
+	go run github.com/hymkor/minipage@latest -outline-in-sidebar -readme-to-index README_ja.md > docs/index_ja.html
 
 .PHONY: all test dist _dist clean manifest release docs

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 SQL-Bless
 ===========
 
-<!-- badges.cmd | -->
+<!-- stdout:go run github.com/hymkor/example-into-readme/cmd/badges@latest -->
 [![Go Test](https://github.com/hymkor/sqlbless/actions/workflows/go.yml/badge.svg)](https://github.com/hymkor/sqlbless/actions/workflows/go.yml)
 [![License](https://img.shields.io/badge/License-MIT-red)](https://github.com/hymkor/sqlbless/blob/master/LICENSE)
 [![Go Reference](https://pkg.go.dev/badge/github.com/hymkor/sqlbless.svg)](https://pkg.go.dev/github.com/hymkor/sqlbless)
+[![GitHub](https://img.shields.io/badge/github-repo-blue?logo=github)](https://github.com/hymkor/sqlbless)
 <!-- -->
 
 **&lt;English&gt;** / [&lt;Japanese&gt;](./README_ja.md)

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,10 +1,11 @@
 SQL-Bless
 =========
 
-<!-- badges.cmd | -->
+<!-- stdout:go run github.com/hymkor/example-into-readme/cmd/badges@latest -->
 [![Go Test](https://github.com/hymkor/sqlbless/actions/workflows/go.yml/badge.svg)](https://github.com/hymkor/sqlbless/actions/workflows/go.yml)
 [![License](https://img.shields.io/badge/License-MIT-red)](https://github.com/hymkor/sqlbless/blob/master/LICENSE)
 [![Go Reference](https://pkg.go.dev/badge/github.com/hymkor/sqlbless.svg)](https://pkg.go.dev/github.com/hymkor/sqlbless)
+[![GitHub](https://img.shields.io/badge/github-repo-blue?logo=github)](https://github.com/hymkor/sqlbless)
 <!-- -->
 
 [&lt;English&gt;](./README.md) / **&lt;Japanese&gt;**


### PR DESCRIPTION
- Makefile:
    - Add `make readme` entry
    - Use `go run minipage` instead of `minipage.exe`
    - `make manifest` uses `go run` instead of make-scoop-manifest.exe
    - Improve `make build`
    - Remove `make get` entry
    - Use `go run latest-notes` instead of `latest-notes.ps1`
- README:
    - Add the badges linked to GitHub Repository
