### PR TITLE
Fixed an issue where the version string was empty when built without GNU Make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,9 @@ manifest:
 release:
 	$(GO) run github.com/hymkor/latest-notes@latest | gh release create -d --notes-file - -t $(VERSION) $(VERSION) $(wildcard $(NAME)-$(VERSION)-*.zip)
 
+bump:
+	$(GO) run github.com/hymkor/latest-notes@latest -suffix "-goinstall" -gosrc sqlbless release_note*.md > version.go
+
 docs:
 	$(GO) run github.com/hymkor/minipage@latest -outline-in-sidebar -readme-to-index README.md    > docs/index.html
 	$(GO) run github.com/hymkor/minipage@latest -outline-in-sidebar -readme-to-index README_ja.md > docs/index_ja.html
@@ -55,4 +58,4 @@ readme:
 	$(GO) run github.com/hymkor/example-into-readme@latest
 	$(GO) run github.com/hymkor/example-into-readme@latest -target README_ja.md
 
-.PHONY: all test dist _dist clean manifest release docs
+.PHONY: all test dist _dist clean manifest release docs bump

--- a/main.go
+++ b/main.go
@@ -52,11 +52,9 @@ func (cfg *Config) Bind(fs *flag.FlagSet) *Config {
 	return cfg
 }
 
-var Version string
-
 func writeSignature(w io.Writer) {
 	fmt.Fprintf(w, "# SQL-Bless %s-%s-%s built with %s\n",
-		Version, runtime.GOOS, runtime.GOARCH, runtime.Version())
+		version, runtime.GOOS, runtime.GOARCH, runtime.Version())
 }
 
 func usage() {

--- a/release_note_en.md
+++ b/release_note_en.md
@@ -2,6 +2,9 @@ Release notes (English)
 =======================
 ( **English** / [Japanese](release_note_ja.md) )
 
+- Fixed an issue where the version string was empty when built without GNU Make.  
+  The version string is now updated via make bump during the release process. (#46)
+
 v0.27.4
 -------
 Feb 14, 2026

--- a/release_note_ja.md
+++ b/release_note_ja.md
@@ -2,6 +2,9 @@ Release notes (Japanese)
 ========================
 ( [English](release_note_en.md) / **Japanese** )
 
+- GNU Make なしでビルドした場合に、バージョン文字列が空になってしまう問題を修正  
+  今後、バージョンアップ時に make bump を実行する (#46)
+
 v0.27.4
 -------
 Feb 14, 2026

--- a/version.go
+++ b/version.go
@@ -1,0 +1,3 @@
+package sqlbless
+
+var version = "v0.27.4-goinstall"


### PR DESCRIPTION
(English)
- Fixed an issue where the version string was empty when built without GNU Make.  
  The version string is now updated via `make bump` during the release process.

(Japanese)
- GNU Make なしでビルドした場合に、バージョン文字列が空になってしまう問題を修正  
  今後、バージョンアップ時に `make bump` を実行する
