### PR TITLE
Rename release note files to CHANGELOG.md and CHANGELOG_ja.md.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-Release notes (English)
+Changelog (English)
 =======================
-( **English** / [Japanese](release_note_ja.md) )
+( **English** / [Japanese](CHANGELOG_ja.md) )
 
 - Fixed an issue where the version string was empty when built without GNU Make.  
   The version string is now updated via make bump during the release process. (#46)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog (English)
 
 - Fixed an issue where the version string was empty when built without GNU Make.  
   The version string is now updated via make bump during the release process. (#46)
+- Rename release note files to CHANGELOG.md and CHANGELOG\_ja.md. (#47)
 
 v0.27.4
 -------

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -1,6 +1,6 @@
-Release notes (Japanese)
+Changelog (Japanese)
 ========================
-( [English](release_note_en.md) / **Japanese** )
+( [English](CHANGELOG.md) / **Japanese** )
 
 - GNU Make なしでビルドした場合に、バージョン文字列が空になってしまう問題を修正  
   今後、バージョンアップ時に make bump を実行する (#46)

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -4,6 +4,7 @@ Changelog (Japanese)
 
 - GNU Make なしでビルドした場合に、バージョン文字列が空になってしまう問題を修正  
   今後、バージョンアップ時に make bump を実行する (#46)
+- リリースノートのファイルを CHANGELOG.md と CHANGELOG\_ja.md へリネーム (#47)
 
 v0.27.4
 -------

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ release:
 	$(GO) run github.com/hymkor/latest-notes@latest | gh release create -d --notes-file - -t $(VERSION) $(VERSION) $(wildcard $(NAME)-$(VERSION)-*.zip)
 
 bump:
-	$(GO) run github.com/hymkor/latest-notes@latest -suffix "-goinstall" -gosrc sqlbless release_note*.md > version.go
+	$(GO) run github.com/hymkor/latest-notes@latest -suffix "-goinstall" -gosrc sqlbless CHANGELOG*.md > version.go
 
 docs:
 	$(GO) run github.com/hymkor/minipage@latest -outline-in-sidebar -readme-to-index README.md    > docs/index.html


### PR DESCRIPTION
(English)
 - Rename release note files to CHANGELOG.md and CHANGELOG\_ja.md

(Japanese)
 - リリースノートのファイルを CHANGELOG.md と CHANGELOG\_ja.md へリネーム