### PR TITLE
Revert "Fix Oracle timestamp comparison failure caused by empty timezone information"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@ Changelog (English)
 =======================
 ( **English** / [Japanese](CHANGELOG_ja.md) )
 
+- Reverted Oracle-specific fix [#49-1] because it caused datetime comparison failures on Microsoft SQL Server. Confirmed that Oracle datetime comparisons work correctly with [#49-2] alone. (#52)
+( This release continues to support Windows 7/8/Server 2008 R2 and Go 1.20.14.)
+
+[#49-1]: https://github.com/hymkor/sqlbless/commit/cc90fc7deb1259861d00bec6bee408abbc59b065
+[#49-2]: https://github.com/hymkor/sqlbless/commit/449a453f240db65e4537311b7c266af14c11af83
+
 v0.27.5
 -------
 May 10, 2026
@@ -17,8 +23,8 @@ This release is the last version supporting Windows 7/8/Server 2008R2 and Go 1.2
   - github.com/nyaosorg/go-ttyadapter  v0.3.0  to v0.7.0
   - github.com/hymkor/go-multiline-ny  v0.22.4 to v0.23.1
   - github.com/hymkor/csvi             v1.22.0 to v1.23.2
-- Fixed an issue where updates to Oracle tables could affect zero rows because datetime values retrieved without timezone information failed to match in WHERE clauses. (#49)
-- github.com/sijms/go-ora v2.9.0 changed DATE/TIMESTAMP timezone handling, which broke datetime comparisons used by SQL-Bless updates. The Oracle driver version has been pinned to v2.8.22 for compatibility. (#49)
+- Fixed an issue where updates to Oracle tables could affect zero rows because datetime values retrieved without timezone information failed to match in WHERE clauses. (#49-1)
+- github.com/sijms/go-ora v2.9.0 changed DATE/TIMESTAMP timezone handling, which broke datetime comparisons used by SQL-Bless updates. The Oracle driver version has been pinned to v2.8.22 for compatibility. (#49-2)
 
 v0.27.4
 -------

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -2,6 +2,12 @@ Changelog (Japanese)
 ========================
 ( [English](CHANGELOG.md) / **Japanese** )
 
+- SQL Server で日時の照合が失敗する問題があったため、Oracle 向けの修正 [#49-1] を Revert した。Oracle 側は [#49-2] があれば問題がないことを確認 (#52)
+( 本バージョンは Windows 7/8/Server 2008R2 と Go 1.20.14 をサポートします )
+
+[#49-1]: https://github.com/hymkor/sqlbless/commit/cc90fc7deb1259861d00bec6bee408abbc59b065
+[#49-2]: https://github.com/hymkor/sqlbless/commit/449a453f240db65e4537311b7c266af14c11af83
+
 v0.27.5
 -------
 May 10, 2026
@@ -17,8 +23,8 @@ May 10, 2026
   - github.com/nyaosorg/go-ttyadapter  v0.3.0  to v0.7.0
   - github.com/hymkor/go-multiline-ny  v0.22.4 to v0.23.1
   - github.com/hymkor/csvi             v1.22.0 to v1.23.2
-- edit文で、Oracle のテーブルを更新しようとした時、timezone 情報が空で取得される日時カラムの照合失敗が原因で、更新が０件になってしまう不具合を修正 (#49)
-- github.com/sijms/go-ora は v2.9.0 で DATE/TIMESTAMP の timezone の扱いが変更され、照合に問題が発生したため、v2.8.22 へ固定 (#49)
+- edit文で、Oracle のテーブルを更新しようとした時、timezone 情報が空で取得される日時カラムの照合失敗が原因で、更新が０件になってしまう不具合を修正 (#49-1)
+- github.com/sijms/go-ora は v2.9.0 で DATE/TIMESTAMP の timezone の扱いが変更され、照合に問題が発生したため、v2.8.22 へ固定 (#49-2)
 
 v0.27.4
 -------

--- a/dialect/main.go
+++ b/dialect/main.go
@@ -202,7 +202,7 @@ type PlaceHolderName struct {
 }
 
 func (ph *PlaceHolderName) Make(v any) string {
-	ph.values = append(ph.values, repair(v))
+	ph.values = append(ph.values, v)
 	return fmt.Sprintf("%s%s%d", ph.Prefix, ph.Format, len(ph.values))
 }
 
@@ -212,21 +212,4 @@ func (ph *PlaceHolderName) Values() (result []any) {
 	}
 	ph.values = ph.values[:0]
 	return
-}
-
-func repair(v any) any {
-	if t, ok := v.(time.Time); ok {
-		if loc := t.Location(); loc != nil && loc.String() == "" {
-			return time.Date(
-				t.Year(),
-				t.Month(),
-				t.Day(),
-				t.Hour(),
-				t.Minute(),
-				t.Second(),
-				t.Nanosecond(),
-				time.Local)
-		}
-	}
-	return v
 }


### PR DESCRIPTION
This reverts commit cc90fc7deb1259861d00bec6bee408abbc59b065.

- Reverted Oracle-specific fix cc90fc7deb1259861d00bec6bee408abbc59b065 because it caused datetime comparison failures on Microsoft SQL Server. Confirmed that Oracle datetime comparisons work correctly with 449a453f240db65e4537311b7c266af14c11af83 alone.
&nbsp;
- SQL Server で日時の照合が失敗する問題があったため、Oracle 向けの修正 cc90fc7deb1259861d00bec6bee408abbc59b065　を Revert した。Oracle 側は 449a453f240db65e4537311b7c266af14c11af83 があれば問題がないことを確認