### PR TITLE
Use TO_DATE/TO_TIMESTAMP for Oracle datetime comparisons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog (English)
   - Upgrade MySQL driver to v1.10.0
   - Upgrade Microsoft SQL Server driver to v1.10.0
   - Upgrade PostgreSQL driver to v1.12.3
+- Oracle datetime values are now passed as strings and converted using `TO_DATE`/`TO_TIMESTAMP` to avoid timezone-related comparison issues in sijms/go-ora. (#55)
 
 v0.27.6
 -------

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -7,6 +7,7 @@ Changelog (Japanese)
   - Upgrade MySQL driver to v1.10.0
   - Upgrade Microsoft SQL Server driver to v1.10.0
   - Upgrade PostgreSQL driver to v1.12.3
+- sijms/go-ora でのタイムゾーンに関する比較問題を回避するため、Oracle の日時値を文字列として引き渡し、`TO_DATE`/`TO_TIMESTAMP` を使ってコンバートするようにした (#55)
 
 v0.27.6
 -------

--- a/dialect/oracle/main.go
+++ b/dialect/oracle/main.go
@@ -1,21 +1,14 @@
 package sqlbless
 
 import (
+	"database/sql"
+	"fmt"
 	"strings"
 
 	_ "github.com/sijms/go-ora/v2"
 
 	"github.com/hymkor/sqlbless/dialect"
 )
-
-func oracleTypeNameToConv(typeName string) func(string) (any, error) {
-	if strings.HasPrefix(typeName, "TIMESTAMP") || typeName == "DATE" {
-		return func(s string) (any, error) {
-			return dialect.ParseAnyDateTime(s)
-		}
-	}
-	return nil
-}
 
 var oracleSpec = &dialect.Entry{
 	Usage: "sqlbless oracle://<USERNAME>:<PASSWORD>@<HOSTNAME>:<PORT>/<SERVICE>",
@@ -39,7 +32,62 @@ var oracleSpec = &dialect.Entry{
 	TypeConverterFor: oracleTypeNameToConv,
 	TableNameField:   "tname",
 	ColumnNameField:  "name",
-	PlaceHolder:      &dialect.PlaceHolderName{Prefix: ":", Format: "v"},
+	PlaceHolder:      new(placeHolder),
+}
+
+type withFormat struct {
+	format string
+	value  any
+}
+
+func oracleTypeNameToConv(typeName string) func(string) (any, error) {
+	var format string
+	var layout string
+
+	if typeName == "DATE" {
+		format = "TO_DATE(:v%d,'YYYY/MM/DD HH24:MI:SS')"
+		layout = "2006/01/02 15:04:05"
+	} else if strings.HasPrefix(typeName, "TIMESTAMP") {
+		format = "TO_TIMESTAMP(:v%d,'YYYY/MM/DD HH24:MI:SS.FF')"
+		layout = "2006/01/02 15:04:05.999999"
+	} else {
+		return nil
+	}
+	return func(s string) (any, error) {
+		dt, err := dialect.ParseAnyDateTime(s)
+		if err != nil {
+			return s, nil
+		}
+		return &withFormat{
+			format: format,
+			value:  dt.Format(layout),
+		}, nil
+	}
+}
+
+type placeHolder struct {
+	values []any
+}
+
+func (ph *placeHolder) Make(v any) string {
+	if w, ok := v.(*withFormat); ok {
+		ph.values = append(ph.values, w.value)
+		return fmt.Sprintf(w.format, len(ph.values))
+	}
+	ph.values = append(ph.values, v)
+	return fmt.Sprintf(":v%d", len(ph.values))
+}
+
+func (ph *placeHolder) NormalizeColumnForWhere(value any, columnName string) string {
+	return columnName
+}
+
+func (ph *placeHolder) Values() (result []any) {
+	for i, v := range ph.values {
+		result = append(result, sql.Named(fmt.Sprintf("v%d", i+1), v))
+	}
+	ph.values = ph.values[:0]
+	return
 }
 
 func init() {


### PR DESCRIPTION
## Changes in this PR (English)

- Oracle datetime values are now passed as strings and converted using `TO_DATE`/`TO_TIMESTAMP` to avoid timezone-related comparison issues in sijms/go-ora.
- Unlike [#49](https://github.com/hymkor/sqlbless/pull/49), this approach does not depend on timezone handling, so in theory it should work with both sijms/go-ora v2.8.22 and v2.9.0.

## Changes in this PR (Japanese)

- sijms/go-ora でのタイムゾーンに関する比較問題を回避するため、Oracle の日時値を文字列として引き渡し、`TO_DATE`/`TO_TIMESTAMP` を使ってコンバートするようにした。
- [#49](https://github.com/hymkor/sqlbless/pull/49) と違って、タイムゾーンに依存しない形にしたため、理論上 sijms/go-ora の 2.8.22 , 2.9.0 いずれでも動作するはず

## References

- [Fix Oracle DATE/TIMESTAMP timezone handling regressions by hymkor · Pull Request #49 · hymkor/sqlbless](https://github.com/hymkor/sqlbless/pull/49)
- [Problem with DATE column mapping after upgrade to version 2.9.0 · Issue #687 · sijms/go-ora](https://github.com/sijms/go-ora/issues/687)