### PR TITLE
test/test-oracle.ps1: Ignore timezone differences in datetime comparisons

### DIFF
--- a/test/test-oracle.ps1
+++ b/test/test-oracle.ps1
@@ -53,11 +53,11 @@ ForEach-Object {
         Write-Host $field.Length
         return
     }
-    if ( $field[1] -ne "2015-06-07 20:21:22 +09:00" ){
+    if ( $field[1] -notlike "2015-06-07 20:21:22*" ){
         Write-Host $field[1]
         return
     }
-    if ( $field[2] -ne "2024-08-09 10:11:12.7878 +09:00" ){
+    if ( $field[2] -notlike "2024-08-09 10:11:12.7878*" ){
         Write-Host $field[2]
         return
     }


### PR DESCRIPTION
* The test results were previously compared assuming the Japanese timezone, causing failures in other regions.
* `go-ora` v2.9.x returns datetime values with UTC timezone information, which also caused the test to fail consistently.
* The test data itself does not include explicit timezone information.
* Therefore, comparing timezone strings in the test results was not meaningful and has been removed.
&nbsp;
- 日本のタイムゾーンを前提として結果が照合されていたため、他の地域では常に失敗していた。
- go-ora 2.9 系では、タイムゾーンが UTC になるため、常に失敗していた。
- テストデータ作成側では、タイムゾーンを記録するようなデータ作成は行っていない。
- それゆえ、テスト結果の照合でタイムゾーンの比較はあまり意味はないため、除外した。