### PR TITLE
Improve Oracle DATE/TIMESTAMP handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog (English)
   - Upgrade Microsoft SQL Server driver to v1.10.0
   - Upgrade PostgreSQL driver to v1.12.3
 - Oracle datetime values are now passed as strings and converted using `TO_DATE`/`TO_TIMESTAMP` to avoid timezone-related comparison issues in sijms/go-ora. (#55)
+- Oracle DATE/TIMESTAMP values are now displayed without timezone suffixes. (#57)
 
 v0.27.6
 -------

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -8,6 +8,7 @@ Changelog (Japanese)
   - Upgrade Microsoft SQL Server driver to v1.10.0
   - Upgrade PostgreSQL driver to v1.12.3
 - sijms/go-ora でのタイムゾーンに関する比較問題を回避するため、Oracle の日時値を文字列として引き渡し、`TO_DATE`/`TO_TIMESTAMP` を使ってコンバートするようにした (#55)
+- Oracle の DATE/TIMESTAMP 値はタイムゾーンなしで表示するようにした (#57)
 
 v0.27.6
 -------

--- a/dialect/main.go
+++ b/dialect/main.go
@@ -56,6 +56,10 @@ type Entry struct {
 
 	// IdentifierEncloser encloses an identifier with dialect-specific quotes.
 	IdentifierEncloser func(name string) string
+
+	// FormatValue converts a database value into a dialect-specific string representation.
+	// Returning false means the default conversion should be used instead.
+	FormatValue func(typeName string, value any) (string, bool)
 }
 
 // EncloseIdentifier returns the given name enclosed with

--- a/dialect/oracle/main.go
+++ b/dialect/oracle/main.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+	"time"
 
 	_ "github.com/sijms/go-ora/v2"
 
@@ -33,6 +34,18 @@ var oracleSpec = &dialect.Entry{
 	TableNameField:   "tname",
 	ColumnNameField:  "name",
 	PlaceHolder:      new(placeHolder),
+	FormatValue:      formatValue,
+}
+
+func formatValue(typeName string, value any) (string, bool) {
+	t, ok := value.(time.Time)
+	if !ok {
+		return "", false
+	}
+	if typeName == "DATE" {
+		return t.Format("2006-01-02 15:04:05"), true
+	}
+	return t.Format("2006-01-02 15:04:05.999999"), true
 }
 
 type withFormat struct {
@@ -45,11 +58,11 @@ func oracleTypeNameToConv(typeName string) func(string) (any, error) {
 	var layout string
 
 	if typeName == "DATE" {
-		format = "TO_DATE(:v%d,'YYYY/MM/DD HH24:MI:SS')"
-		layout = "2006/01/02 15:04:05"
+		format = "TO_DATE(:v%d,'YYYY-MM-DD HH24:MI:SS')"
+		layout = "2006-01-02 15:04:05"
 	} else if strings.HasPrefix(typeName, "TIMESTAMP") {
-		format = "TO_TIMESTAMP(:v%d,'YYYY/MM/DD HH24:MI:SS.FF')"
-		layout = "2006/01/02 15:04:05.999999"
+		format = "TO_TIMESTAMP(:v%d,'YYYY-MM-DD HH24:MI:SS.FF')"
+		layout = "2006-01-02 15:04:05.999999"
 	} else {
 		return nil
 	}

--- a/edit.go
+++ b/edit.go
@@ -51,6 +51,7 @@ func newViewer(ss *session) *spread.Viewer {
 		hl = 1
 	}
 	return &spread.Viewer{
+		Entry:       ss.Dialect,
 		HeaderLines: hl,
 		Comma:       ss.comma(),
 		Null:        ss.Null,
@@ -80,12 +81,12 @@ func chooseTable(ctx context.Context, tables []string, d *dialect.Entry, ttyout 
 func doEdit(ctx context.Context, ss *session, command string, pilot commandIn) error {
 	editor := &spread.Editor{
 		Viewer: &spread.Viewer{
+			Entry:       ss.Dialect,
 			HeaderLines: 1,
 			Comma:       ss.comma(),
 			Null:        ss.Null,
 		},
-		Entry: ss.Dialect,
-		Exec:  (&askSqlAndExecute{getKey: pilot.GetKey, session: ss}).Exec,
+		Exec: (&askSqlAndExecute{getKey: pilot.GetKey, session: ss}).Exec,
 	}
 	if a, ok := pilot.AutoPilotForCsvi(); ok {
 		editor.Pilot = misc.AutoCsvi{GetKeyAndSize: a}

--- a/rowstocsv/main.go
+++ b/rowstocsv/main.go
@@ -19,19 +19,15 @@ type Source interface {
 	Scan(dest ...any) error
 }
 
-func anyToNullString(v any) sql.NullString {
-	var ns sql.NullString
+func anyToNullString(v any) (string, bool) {
 	if stamp, ok := v.(time.Time); ok {
-		ns.String = stamp.Format("2006-01-02 15:04:05.999999999 -07:00")
-		ns.Valid = true
+		return stamp.Format("2006-01-02 15:04:05.999999999 -07:00"), true
 	} else if b, ok := v.([]byte); ok {
-		ns.String = string(b)
-		ns.Valid = true
+		return string(b), true
 	} else if v != nil {
-		ns.String = fmt.Sprint(v)
-		ns.Valid = true
+		return fmt.Sprint(v), true
 	}
-	return ns
+	return "", false
 }
 
 func makeBuffers[T any](n int) ([]any, []T) {
@@ -43,7 +39,7 @@ func makeBuffers[T any](n int) ([]any, []T) {
 	return refs, data
 }
 
-func dump(ctx context.Context, rows Source, conv func(int, *sql.ColumnType, sql.NullString) string, debug bool, write func([]string) error) error {
+func dump(ctx context.Context, rows Source, conv func(int, *sql.ColumnType, any) (string, bool), null string, debug bool, write func([]string) error) error {
 	columns, err := rows.Columns()
 	if err != nil {
 		return fmt.Errorf("(sql.Rows) Columns: %w", err)
@@ -55,7 +51,6 @@ func dump(ctx context.Context, rows Source, conv func(int, *sql.ColumnType, sql.
 
 	n := len(columns)
 	refs, data := makeBuffers[any](n)
-	//refs, data := makeBuffers[sql.RawBytes](n)
 	strs := make([]string, len(columns))
 
 	columnTypes, err := rows.ColumnTypes()
@@ -83,17 +78,25 @@ func dump(ctx context.Context, rows Source, conv func(int, *sql.ColumnType, sql.
 	}
 
 	for rows.Next() {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
+		if err := ctx.Err(); err != nil {
+			return err
 		}
 		if err := rows.Scan(refs...); err != nil {
 			return err
 		}
 		for i, v := range data {
-			ns := anyToNullString(v)
-			strs[i] = conv(i, columnTypes[i], ns)
+			if conv != nil {
+				s, ok := conv(i, columnTypes[i], v)
+				if ok {
+					strs[i] = s
+					continue
+				}
+			}
+			if s, ok := anyToNullString(v); ok {
+				strs[i] = s
+			} else {
+				strs[i] = null
+			}
 		}
 		if err := write(strs); err != nil {
 			return fmt.Errorf("(csv.Writer).Write: %w", err)
@@ -110,15 +113,8 @@ type Config struct {
 	UseCRLF   bool
 	Null      string
 	Debug     bool
-	Conv      func(int, *sql.ColumnType, sql.NullString) string
+	Conv      func(int, *sql.ColumnType, any) (string, bool)
 	AutoClose bool
-}
-
-func (cfg Config) defaultConv(_ int, _ *sql.ColumnType, v sql.NullString) string {
-	if v.Valid {
-		return v.String
-	}
-	return cfg.Null
 }
 
 func (cfg Config) Dump(ctx context.Context, rows Source, w io.Writer) error {
@@ -128,12 +124,8 @@ func (cfg Config) Dump(ctx context.Context, rows Source, w io.Writer) error {
 	csvw.Comma = cfg.Comma
 	csvw.UseCRLF = cfg.UseCRLF
 
-	conv := cfg.defaultConv
-	if cfg.Conv != nil {
-		conv = cfg.Conv
-	}
 	if cfg.AutoClose {
 		defer rows.Close()
 	}
-	return dump(ctx, rows, conv, cfg.Debug, csvw.Write)
+	return dump(ctx, rows, cfg.Conv, cfg.Null, cfg.Debug, csvw.Write)
 }

--- a/spread/edit.go
+++ b/spread/edit.go
@@ -93,7 +93,6 @@ func doubleQuoteIfNeed(s string) string {
 
 type Editor struct {
 	*Viewer
-	*dialect.Entry
 	Query func(context.Context, string, ...any) (*sql.Rows, error)
 	Exec  func(context.Context, string, ...any) (sql.Result, error)
 }
@@ -195,6 +194,12 @@ func (editor *Editor) Edit(ctx context.Context, tableAndWhere string, termOut io
 			Null:      editor.Viewer.Null,
 			Comma:     rune(editor.Viewer.Comma),
 			AutoClose: true,
+			Conv: func(_ int, ct *sql.ColumnType, v any) (string, bool) {
+				if f := editor.Entry.FormatValue; f != nil {
+					return f(ct.DatabaseTypeName(), v)
+				}
+				return "", false
+			},
 		}.Dump(ctx, rows, w)
 		rows = nil
 		return err

--- a/spread/view.go
+++ b/spread/view.go
@@ -2,12 +2,14 @@ package spread
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"io"
 	"strings"
 
 	"github.com/hymkor/csvi"
 	"github.com/hymkor/csvi/uncsv"
+	"github.com/hymkor/sqlbless/dialect"
 	"github.com/hymkor/sqlbless/rowstocsv"
 )
 
@@ -17,6 +19,7 @@ type KeyBinding struct {
 }
 
 type Viewer struct {
+	*dialect.Entry
 	HeaderLines int
 	Comma       byte
 	Null        string
@@ -41,6 +44,12 @@ func (viewer *Viewer) View(ctx context.Context, title string, rows rowstocsv.Sou
 			Null:      viewer.Null,
 			Comma:     rune(viewer.Comma),
 			AutoClose: true,
+			Conv: func(_ int, ct *sql.ColumnType, v any) (string, bool) {
+				if f := viewer.Entry.FormatValue; f != nil {
+					return f(ct.DatabaseTypeName(), v)
+				}
+				return "", false
+			},
 		}.Dump(ctx, rows, w)
 	}
 

--- a/test/test-oracle.ps1
+++ b/test/test-oracle.ps1
@@ -53,11 +53,11 @@ ForEach-Object {
         Write-Host $field.Length
         return
     }
-    if ( $field[1] -notlike "2015-06-07 20:21:22*" ){
+    if ( $field[1] -ne "2015-06-07 20:21:22" ){
         Write-Host $field[1]
         return
     }
-    if ( $field[2] -notlike "2024-08-09 10:11:12.7878*" ){
+    if ( $field[2] -ne "2024-08-09 10:11:12.7878" ){
         Write-Host $field[2]
         return
     }


### PR DESCRIPTION
## Summary

This PR improves Oracle DATE/TIMESTAMP handling and avoids timezone-dependent behavior caused by differences in Oracle driver implementations.

Instead of relying on Go `time.Time` timezone handling, Oracle datetime values are now converted through database-specific string formatting and SQL-side `TO_DATE` / `TO_TIMESTAMP` conversion.

## Changes

* Add `FormatValue` hook to `dialect.Entry`
  * allows database-specific string formatting for displayed values
* Improve conversion hooks in `rowstocsv`
  * refine hook timing and parameters for database-to-CSV conversion
* Apply dialect-specific formatting in `spread`
  * `select` and `edit` now use database-specific cell formatting
* Add Oracle-specific datetime formatting
  * `DATE` values are formatted as:
    * `2006-01-02 15:04:05`
  * `TIMESTAMP` values are formatted as:
    * `2006-01-02 15:04:05.999999999`
* Use `TO_DATE` / `TO_TIMESTAMP` for Oracle datetime comparisons and updates
* Update Oracle tests
  * timezone strings are no longer expected in Oracle datetime output

## Notes

Oracle `DATE` and `TIMESTAMP` columns do not contain timezone information, but different versions of `go-ora` attach different timezone metadata to Go `time.Time` values.

This PR avoids relying on timezone behavior and instead uses timezone-independent string representations for Oracle datetime handling.

Unlike [[#49](https://github.com/hymkor/sqlbless/pull/49)](https://github.com/hymkor/sqlbless/pull/49), this approach should theoretically work with both `go-ora` v2.8.x and v2.9.x.

---

go-ora ドライバーって、2.8 だと time.Time に入ってくるタイムゾーンが time.Local になるのに、2.9 だと UTC になってしまいます。で、それだとレコードの照合がうまくいかなくなるのが困るので、[#55](https://github.com/hymkor/sqlbless/pull/55) では、日時の照合と日時の名前の値ではなく、TO_DATE , TO_TIMESTAMP を経由使って行うようにしました。
その結果として、edit コマンドや select コマンドで出てくるタイムゾーン情報（例：+09:00）は無意味になってしまいました（ユーザが編集しても使わない）。ならばそもそも表示しないようにしようというのが本修正です。

ただし、Oracle 向けの特別扱いはよくないため、本修正では、各DBごとに SELECT/EDIT 文で出す表現情報をカスタマイズできるような仕組みを作ってから、それを使いました。今後、他の DB 向けにもこの仕組みを使うと思います。
（dialent サブパッケージの Entry 構造体の FormatValue フィールドに格納されている関数に型名と値を渡せば、その DB 固有の表現が得られるという仕組み。ただし、フィールドが空の場合や、第二戻り値が false の場合は固有のカスタマイズはないと解釈しなければいけない）