### PR TITLE
`edit`: Handle SQLite datetime values as wall-clock strings without timezone information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@ Changelog (English)
   - Upgrade MySQL driver to v1.10.0
   - Upgrade Microsoft SQL Server driver to v1.10.0
   - Upgrade PostgreSQL driver to v1.12.3
-- Oracle datetime values are now passed as strings and converted using `TO_DATE`/`TO_TIMESTAMP` to avoid timezone-related comparison issues in sijms/go-ora. (#55)
-- Oracle DATE/TIMESTAMP values are now displayed without timezone suffixes. (#57)
+- Oracle and SQLite datetime values displayed by select and edit no longer include redundant timezone suffixes. Datetime comparisons are now handled using timezone-independent string conversion. (#55, #57, #58)
 
 v0.27.6
 -------

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -7,8 +7,7 @@ Changelog (Japanese)
   - Upgrade MySQL driver to v1.10.0
   - Upgrade Microsoft SQL Server driver to v1.10.0
   - Upgrade PostgreSQL driver to v1.12.3
-- sijms/go-ora でのタイムゾーンに関する比較問題を回避するため、Oracle の日時値を文字列として引き渡し、`TO_DATE`/`TO_TIMESTAMP` を使ってコンバートするようにした (#55)
-- Oracle の DATE/TIMESTAMP 値はタイムゾーンなしで表示するようにした (#57)
+- SELECT や EDIT で表示される Oracle と SQLite の日時から冗長なタイムゾーンを除いた。日時の照合もタイムゾーンに依存しないよう変換した文字列で行うようにした (#55, #57, #58)
 
 v0.27.6
 -------

--- a/dialect/sqlite/main.go
+++ b/dialect/sqlite/main.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+	"time"
 
 	_ "github.com/glebarez/go-sqlite/compat"
 
@@ -29,6 +30,22 @@ var Entry = &dialect.Entry{
 		s, _ = misc.CutField(s)
 		return strings.EqualFold(s, "PRAGMA")
 	},
+	FormatValue: formatValue,
+}
+
+func formatValue(typeName string, value any) (string, bool) {
+	if t, ok := value.(time.Time); ok {
+		if typeName == "DATE" {
+			return t.Format("2006-01-02"), true
+		}
+		if typeName == "DATETIME" {
+			return t.Format("2006-01-02 15:04:05"), true
+		}
+		if typeName == "TIMESTAMP" {
+			return t.Format("2006-01-02 15:04:05.999999999"), true
+		}
+	}
+	return "", false
 }
 
 func canUseInTransaction(sql string) bool {
@@ -37,11 +54,19 @@ func canUseInTransaction(sql string) bool {
 	return !strings.EqualFold(keyword, "VACUUM")
 }
 
-var typeNameToHolder = map[string]string{
-	"TIMESTAMP": "datetime(?)", // "2006-01-02 15:04:05.999999999-07:00"
-	"TIME":      "time(?)",     // dialect.TimeOnlyLayout
-	"DATE":      "date(?)",     // dialect.DateOnlyLayout
-	"DATETIME":  "datetime(?)", // dialect.DateTimeLayout
+var typeNameToHolder = map[string][2]string{
+	"TIMESTAMP": [2]string{
+		"strftime('%Y-%m-%d %H:%M:%f',?)", // "2006-01-02 15:04:05.999999999-07:00"
+		"2006-01-02 15:04:05.999999999"},
+	"TIME": [2]string{
+		"time(?)", // dialect.TimeOnlyLayout
+		"15:04:05"},
+	"DATE": [2]string{
+		"date(?)", // dialect.DateOnlyLayout
+		"2006-01-02"},
+	"DATETIME": [2]string{
+		"datetime(?)", // dialect.DateTimeLayout
+		"2006-01-02 15:04:05"},
 }
 
 func typeNameToConv(typeName string) func(string) (any, error) {
@@ -51,7 +76,10 @@ func typeNameToConv(typeName string) func(string) (any, error) {
 			if err != nil {
 				return s, nil
 			}
-			return &withHolder{holder: holder, value: dt}, nil
+			return &withHolder{
+				holder: holder[0],
+				value:  dt.Format(holder[1]),
+			}, nil
 		}
 	}
 	return nil


### PR DESCRIPTION
- Removed redundant +00:00 timezone suffixes from datetime values displayed by select and edit on SQLite.
&nbsp;
- SELECT文・EDIT文で表示される日時表現から、冗長なタイムゾーン情報 +00:00 を省くようにした