### PR TITLE
Fix: confirmation to apply changes to the DB was skipped when only NULL values were modified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog (English)
   - Upgrade Microsoft SQL Server driver to v1.10.0
   - Upgrade PostgreSQL driver to v1.12.3
 - Oracle and SQLite datetime values displayed by select and edit no longer include redundant timezone suffixes. Datetime comparisons are now handled using timezone-independent string conversion. (#55, #57, #58)
+- Fix: confirmation to apply changes to the DB was skipped when only NULL values were modified (#59)
 
 v0.27.6
 -------

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -8,6 +8,7 @@ Changelog (Japanese)
   - Upgrade Microsoft SQL Server driver to v1.10.0
   - Upgrade PostgreSQL driver to v1.12.3
 - SELECT や EDIT で表示される Oracle と SQLite の日時から冗長なタイムゾーンを除いた。日時の照合もタイムゾーンに依存しないよう変換した文字列で行うようにした (#55, #57, #58)
+- edit 文で NULL の設定のみを変更した場合、変更反映の確認が行われない不具合を修正 (#59)
 
 v0.27.6
 -------

--- a/spread/view.go
+++ b/spread/view.go
@@ -67,6 +67,7 @@ func (viewer *Viewer) View(ctx context.Context, title string, rows rowstocsv.Sou
 func (viewer *Viewer) edit(title string, validate func(*csvi.CellValidatedEvent) (string, error), csvWriteTo func(pOut io.Writer) error, termOut io.Writer) (*csvi.Result, error) {
 
 	applyChange := false
+	myDirty := false
 	setNull := func(e *csvi.KeyEventArgs) (*csvi.CommandResult, error) {
 		if e.CurrentRow().Index() < viewer.HeaderLines {
 			return &csvi.CommandResult{}, nil
@@ -80,11 +81,12 @@ func (viewer *Viewer) edit(title string, validate func(*csvi.CellValidatedEvent)
 			return &csvi.CommandResult{Message: err.Error()}, nil
 		}
 		e.CurrentRow().Replace(e.CurrentCol(), viewer.Null, &uncsv.Mode{Comma: viewer.Comma})
+		myDirty = true
 		return &csvi.CommandResult{}, nil
 	}
 
 	quit := func(app *csvi.KeyEventArgs) (*csvi.CommandResult, error) {
-		if !app.IsDirty() {
+		if !app.IsDirty() && !myDirty {
 			io.WriteString(app, "\n")
 			return &csvi.CommandResult{Quit: true}, nil
 		}


### PR DESCRIPTION
- Fix: confirmation to apply changes to the DB was skipped when only NULL values were modified
&nbsp;
- edit 文で NULL の設定のみを変更した場合、変更反映の確認が行われない不具合を修正
