### PR TITLE
`edit`: Improve readability of timestamp bind variable output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog (English)
   - Upgrade PostgreSQL driver to v1.12.3
 - Oracle and SQLite datetime values displayed by select and edit no longer include redundant timezone suffixes. Datetime comparisons are now handled using timezone-independent string conversion. (#55, #57, #58)
 - Fix: confirmation to apply changes to the DB was skipped when only NULL values were modified (#59)
+- Improved readability of timestamp values shown in bind variable output during edit operations. (#60)
 
 v0.27.6
 -------

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -9,6 +9,7 @@ Changelog (Japanese)
   - Upgrade PostgreSQL driver to v1.12.3
 - SELECT や EDIT で表示される Oracle と SQLite の日時から冗長なタイムゾーンを除いた。日時の照合もタイムゾーンに依存しないよう変換した文字列で行うようにした (#55, #57, #58)
 - edit 文で NULL の設定のみを変更した場合、変更反映の確認が行われない不具合を修正 (#59)
+- edit 文でバインド変数出力の日時を読み易さを改善した (#60)
 
 v0.27.6
 -------

--- a/edit.go
+++ b/edit.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/nyaosorg/go-box/v3"
 
@@ -117,10 +118,21 @@ func joinAny(args []any) string {
 	}
 	var b strings.Builder
 	for i, v := range args {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		var val any
 		if n, ok := v.(sql.NamedArg); ok {
-			fmt.Fprintf(&b, "(%s) %#v ", n.Name, n.Value)
+			fmt.Fprintf(&b, "(%s) ", n.Name)
+			val = n.Value
 		} else {
-			fmt.Fprintf(&b, "(%d) %#v ", i+1, v)
+			fmt.Fprintf(&b, "(%d) ", i+1)
+			val = v
+		}
+		if t, ok := val.(time.Time); ok {
+			b.WriteString(t.Format("2006-01-02 15:04:05.999999999 -07:00"))
+		} else {
+			fmt.Fprintf(&b, "%#v", val)
 		}
 	}
 	return b.String()


### PR DESCRIPTION
- Improved readability of timestamp values shown in bind variable output during edit operations.
&nbsp;
- edit 文でバインド変数出力の日時を読み易さを改善した

Before: `(v1) time.Date(2015, time.June, 7, 20, 21, 22, 0, time.Local)`
After: `\n(v1) 2021-01-01 00:00:01 -07:00`