### PR TITLE
`edit` supports TIMESTAMP WITH TIME ZONE and LOCAL TIME ZONE on Oracle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog (English)
 - Fix: confirmation to apply changes to the DB was skipped when only NULL values were modified (#59)
 - Improved readability of timestamp values shown in bind variable output during edit operations. (#60)
 - Fixed missing error messages when INSERT, UPDATE, or DELETE statements failed. (#61)
+- Added support for Oracle TIMESTAMP WITH TIME ZONE and TIMESTAMP WITH LOCAL TIME ZONE columns in edit mode. (#63)
 
 v0.27.6
 -------

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -11,6 +11,7 @@ Changelog (Japanese)
 - edit 文で NULL の設定のみを変更した場合、変更反映の確認が行われない不具合を修正 (#59)
 - edit 文でバインド変数出力の日時を読み易さを改善した (#60)
 - INSERT/UPDATE/DELETE で発生したエラーが表示されない不具合を修正 (#61)
+- edit 文で Oracle の TIMESTAMP WITH TIME ZONE, TIMESTAMP WITH LOCAL TIME ZONE 型をサポート (#63)
 
 v0.27.6
 -------

--- a/dialect/oracle/main.go
+++ b/dialect/oracle/main.go
@@ -45,6 +45,11 @@ func formatValue(typeName string, value any) (string, bool) {
 	if typeName == "DATE" {
 		return t.Format("2006-01-02 15:04:05"), true
 	}
+	if strings.EqualFold(typeName, "TimeStampTZ_DTY") ||
+		strings.EqualFold(typeName, "TimeStampLTZ_DTY") {
+
+		return t.Format("2006-01-02 15:04:05.999999 -07:00"), true
+	}
 	return t.Format("2006-01-02 15:04:05.999999"), true
 }
 
@@ -61,8 +66,15 @@ func oracleTypeNameToConv(typeName string) func(string) (any, error) {
 		format = "TO_DATE(:v%d,'YYYY-MM-DD HH24:MI:SS')"
 		layout = "2006-01-02 15:04:05"
 	} else if strings.HasPrefix(typeName, "TIMESTAMP") {
-		format = "TO_TIMESTAMP(:v%d,'YYYY-MM-DD HH24:MI:SS.FF')"
-		layout = "2006-01-02 15:04:05.999999"
+		if strings.EqualFold(typeName, "TimeStampTZ_DTY") ||
+			strings.EqualFold(typeName, "TimeStampLTZ_DTY") {
+
+			format = "TO_TIMESTAMP_TZ(:v%d,'YYYY-MM-DD HH24:MI:SS.FF TZH:TZM')"
+			layout = "2006-01-02 15:04:05.999999 -07:00"
+		} else {
+			format = "TO_TIMESTAMP(:v%d,'YYYY-MM-DD HH24:MI:SS.FF')"
+			layout = "2006-01-02 15:04:05.999999"
+		}
 	} else {
 		return nil
 	}


### PR DESCRIPTION
- Added support for Oracle TIMESTAMP WITH TIME ZONE and TIMESTAMP WITH LOCAL TIME ZONE columns in edit mode.
&nbsp;
- edit 文で Oracle の TIMESTAMP WITH TIME ZONE, TIMESTAMP WITH LOCAL TIME ZONE 型をサポート
