### PR TITLE
`edit` hides timezone offsets for timezone-less PostgreSQL timestamp columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog (English)
 - Oracle and SQLite datetime values displayed by select and edit no longer include redundant timezone suffixes. Datetime comparisons are now handled using timezone-independent string conversion. (#55, #57, #58)
 - Improved readability of timestamp values shown in bind variable output during edit operations. (#60)
 - Added support for Oracle TIMESTAMP WITH TIME ZONE and TIMESTAMP WITH LOCAL TIME ZONE columns in edit mode. (#63)
+- Improved PostgreSQL timestamp display in edit mode by hiding timezone offsets for columns without timezone information. (#65)
 
 v0.27.7
 -------

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -10,6 +10,7 @@ Changelog (Japanese)
 - SELECT や EDIT で表示される Oracle と SQLite の日時から冗長なタイムゾーンを除いた。日時の照合もタイムゾーンに依存しないよう変換した文字列で行うようにした (#55, #57, #58)
 - edit 文でバインド変数出力の日時を読み易さを改善した (#60)
 - edit 文で Oracle の TIMESTAMP WITH TIME ZONE, TIMESTAMP WITH LOCAL TIME ZONE 型をサポート (#63)
+- PostgreSQL でタイムゾーン情報がないカラムでは edit 文でタイムゾーンのオフセットを表示させないようにした (#65)
 
 v0.27.7
 -------

--- a/dialect/postgresql/main.go
+++ b/dialect/postgresql/main.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	_ "github.com/lib/pq"
 
@@ -15,7 +16,7 @@ var postgresTypeNameToFormat = map[string][2]string{
 	"TIMESTAMP":   [2]string{"TIMESTAMP", dialect.DateTimeLayout},
 	"DATE":        [2]string{"DATE", dialect.DateOnlyLayout},
 	"TIMETZ":      [2]string{"TIME WITH TIME ZONE", dialect.TimeTzLayout},
-	"TIME":        [2]string{"TIME", dialect.TimeTzLayout},
+	"TIME":        [2]string{"TIME", dialect.TimeOnlyLayout},
 }
 
 func postgresTypeNameToConv(typeName string) func(string) (any, error) {
@@ -73,6 +74,19 @@ var postgresSpec = &dialect.Entry{
 	TableNameField:    "table_name",
 	ColumnNameField:   "name",
 	IsTransactionSafe: canUseInTransaction,
+	FormatValue:       formatValue,
+}
+
+func formatValue(typeName string, value any) (string, bool) {
+	t, ok := value.(time.Time)
+	if !ok {
+		return "", false
+	}
+	f, ok := postgresTypeNameToFormat[typeName]
+	if !ok {
+		return "", false
+	}
+	return t.Format(f[1]), true
 }
 
 func canUseInTransaction(sql string) bool {


### PR DESCRIPTION
- Improved PostgreSQL timestamp display in edit mode by hiding timezone offsets for columns without timezone information.
&nbsp;
- PostgreSQL でタイムゾーン情報がないカラムでは edit 文でタイムゾーンのオフセットを表示させないようにした
