### PR TITLE
`edit`: Handle SQL-Server datetime values as wall-clock strings without timezone information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,9 @@ Changelog (English)
   - Upgrade MySQL driver to v1.10.0
   - Upgrade Microsoft SQL Server driver to v1.10.0
   - Upgrade PostgreSQL driver to v1.12.3
-- Oracle and SQLite datetime values displayed by select and edit no longer include redundant timezone suffixes. Datetime comparisons are now handled using timezone-independent string conversion. (#55, #57, #58)
-- Improved readability of timestamp values shown in bind variable output during edit operations. (#60)
-- Added support for Oracle TIMESTAMP WITH TIME ZONE and TIMESTAMP WITH LOCAL TIME ZONE columns in edit mode. (#63)
-- Improved PostgreSQL timestamp display in edit mode by hiding timezone offsets for columns without timezone information. (#65)
+- Improved datetime handling in SELECT and EDIT operations. Columns without timezone information no longer display redundant timezone offsets, and fields without certain precision (such as seconds) no longer show unnecessary components. Datetime comparison and update matching are now performed using string representations appropriate for each column type. Supported for Oracle, PostgreSQL, SQLite, and SQL Server. (#55, #57, #58, #65, #66)
+- Improved readability of datetime values shown in bind variable output during edit operations. (#60)
+- Added support for Oracle TIMESTAMP WITH TIME ZONE / TIMESTAMP WITH LOCAL TIME ZONE and SQL Server DATETIMEOFFSET columns in edit mode. (#63, #66)
 
 v0.27.7
 -------

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -7,10 +7,9 @@ Changelog (Japanese)
   - Upgrade MySQL driver to v1.10.0
   - Upgrade Microsoft SQL Server driver to v1.10.0
   - Upgrade PostgreSQL driver to v1.12.3
-- SELECT や EDIT で表示される Oracle と SQLite の日時から冗長なタイムゾーンを除いた。日時の照合もタイムゾーンに依存しないよう変換した文字列で行うようにした (#55, #57, #58)
-- edit 文でバインド変数出力の日時を読み易さを改善した (#60)
-- edit 文で Oracle の TIMESTAMP WITH TIME ZONE, TIMESTAMP WITH LOCAL TIME ZONE 型をサポート (#63)
-- PostgreSQL でタイムゾーン情報がないカラムでは edit 文でタイムゾーンのオフセットを表示させないようにした (#65)
+- SELECT / EDIT における日時表示を改善。タイムゾーン情報を持たないカラムでは不要なタイムゾーン表示を行わないようにし、精度を持たない項目（例: 秒）も表示しないようにした。日時比較や更新時の照合も、各カラム型に応じた文字列形式で行うよう改善した。Oracle / PostgreSQL / SQLite / SQL Server に対応。 (#55, #57, #58, #65, #66)
+- edit 文のバインド変数出力における日時表示の読み易さを改善した。 (#60)
+- edit 文で Oracle TIMESTAMP WITH TIME ZONE / TIMESTAMP WITH LOCAL TIME ZONE および SQL Server DATETIMEOFFSET 型をサポートした。 (#63, #66)
 
 v0.27.7
 -------

--- a/dialect/main.go
+++ b/dialect/main.go
@@ -6,8 +6,6 @@ import (
 	"regexp"
 	"strings"
 	"time"
-
-	"database/sql"
 )
 
 var (
@@ -80,21 +78,25 @@ func (D *Entry) LookupConverter(typeName string) func(string) (any, error) {
 }
 
 const (
-	DateTimeTzLayout = "2006-01-02 15:04:05.999999999 -07:00"
-	DateTimeLayout   = "2006-01-02 15:04:05.999999999"
-	DateOnlyLayout   = "2006-01-02"
-	TimeOnlyLayout   = "15:04:05.999999999"
-	TimeTzLayout     = "15:04:05.999999999 -07:00"
-	RawTimeLayout    = "2006-01-02T15:04:05Z"
+	DateTimeTzLayout    = "2006-01-02 15:04:05.999999999 -07:00"
+	DateTimeLayout      = "2006-01-02 15:04:05.999999999"
+	DateTimeLayout7p    = "2006-01-02 15:04:05.0000000"
+	DateTimeLayout3p    = "2006-01-02 15:04:05.000"
+	ShortDateTimeLayout = "2006-01-02 15:04"
+	DateOnlyLayout      = "2006-01-02"
+	TimeOnlyLayout      = "15:04:05.999999999"
+	TimeTzLayout        = "15:04:05.999999999 -07:00"
+	RawTimeLayout       = "2006-01-02T15:04:05Z"
 )
 
 var (
-	rxDateTimeTz = regexp.MustCompile(`^\s*(\d{4}-\d\d-\d\d \d\d:\d\d:\d\d(?:\.\d+)?)\s*([\-\+]?)(\d\d?):(\d\d)\s*$`)
-	rxDateTime   = regexp.MustCompile(`^\s*(\d{4}-\d\d-\d\d \d\d:\d\d:\d\d(?:\.\d+)?)\s*$`)
-	rxDateOnly   = regexp.MustCompile(`^\s*(\d{4}-\d\d-\d\d)\s*$`)
-	rxTimeTz     = regexp.MustCompile(`^\s*(?:\d{4}-\d\d-\d\d )?(\d\d:\d\d:\d\d(?:\.\d+)? [-\+]\d\d:\d\d)\s*$`)
-	rxTimeOnly   = regexp.MustCompile(`^\s*(?:\d{4}-\d\d-\d\d )?(\d\d:\d\d:\d\d(?:\.\d+)?)\s*$`)
-	rxRawLayout  = regexp.MustCompile(`^\s*(\d{4}-\d\d-\d\dT\d\d:\d\d:\d\dZ)\s*$`)
+	rxDateTimeTz    = regexp.MustCompile(`^\s*(\d{4}-\d\d-\d\d \d\d:\d\d:\d\d(?:\.\d+)?)\s*([\-\+]?)(\d\d?):(\d\d)\s*$`)
+	rxDateTime      = regexp.MustCompile(`^\s*(\d{4}-\d\d-\d\d \d\d:\d\d:\d\d(?:\.\d+)?)\s*$`)
+	rxShortDateTime = regexp.MustCompile(`^\s*(\d{4}-\d\d-\d\d \d\d:\d\d)\s*$`)
+	rxDateOnly      = regexp.MustCompile(`^\s*(\d{4}-\d\d-\d\d)\s*$`)
+	rxTimeTz        = regexp.MustCompile(`^\s*(?:\d{4}-\d\d-\d\d )?(\d\d:\d\d:\d\d(?:\.\d+)? [-\+]\d\d:\d\d)\s*$`)
+	rxTimeOnly      = regexp.MustCompile(`^\s*(?:\d{4}-\d\d-\d\d )?(\d\d:\d\d:\d\d(?:\.\d+)?)\s*$`)
+	rxRawLayout     = regexp.MustCompile(`^\s*(\d{4}-\d\d-\d\dT\d\d:\d\d:\d\dZ)\s*$`)
 )
 
 func ParseAnyDateTime(s string) (time.Time, error) {
@@ -108,6 +110,9 @@ func ParseAnyDateTime(s string) (time.Time, error) {
 	if m := rxDateOnly.FindStringSubmatch(s); m != nil {
 		return time.Parse(DateOnlyLayout, m[1])
 	}
+	if m := rxShortDateTime.FindStringSubmatch(s); m != nil {
+		return time.ParseInLocation(ShortDateTimeLayout, m[1], time.Local)
+	}
 	if m := rxTimeTz.FindStringSubmatch(s); m != nil {
 		return time.Parse(TimeTzLayout, m[1])
 	}
@@ -117,7 +122,7 @@ func ParseAnyDateTime(s string) (time.Time, error) {
 	if m := rxRawLayout.FindStringSubmatch(s); m != nil {
 		return time.Parse(RawTimeLayout, m[1])
 	}
-	return time.Time{}, ErrNotTimeFormat
+	return time.Time{}, fmt.Errorf("%w: %s", ErrNotTimeFormat, s)
 }
 
 var registry = map[string]*Entry{}
@@ -195,25 +200,6 @@ func (ph *PlaceHolderQuestion) Make(v any) string {
 
 func (ph *PlaceHolderQuestion) Values() (result []any) {
 	result = ph.values
-	ph.values = ph.values[:0]
-	return
-}
-
-type PlaceHolderName struct {
-	Prefix string
-	Format string
-	values []any
-}
-
-func (ph *PlaceHolderName) Make(v any) string {
-	ph.values = append(ph.values, v)
-	return fmt.Sprintf("%s%s%d", ph.Prefix, ph.Format, len(ph.values))
-}
-
-func (ph *PlaceHolderName) Values() (result []any) {
-	for i, v := range ph.values {
-		result = append(result, sql.Named(fmt.Sprintf("%s%d", ph.Format, i+1), v))
-	}
 	ph.values = ph.values[:0]
 	return
 }

--- a/dialect/placeholdern.go
+++ b/dialect/placeholdern.go
@@ -1,0 +1,34 @@
+package dialect
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+type SQLFmtAndValue struct {
+	Format string
+	Value  any
+}
+
+type PlaceHolderName struct {
+	Mark   string // e.g., `@` or ``
+	Prefix string // e.g., `v`
+	values []any
+}
+
+func (ph *PlaceHolderName) Make(v any) string {
+	if wf, ok := v.(*SQLFmtAndValue); ok {
+		ph.values = append(ph.values, wf.Value)
+		return fmt.Sprintf(wf.Format, len(ph.values))
+	}
+	ph.values = append(ph.values, v)
+	return fmt.Sprintf("%s%s%d", ph.Mark, ph.Prefix, len(ph.values))
+}
+
+func (ph *PlaceHolderName) Values() (result []any) {
+	for i, v := range ph.values {
+		result = append(result, sql.Named(fmt.Sprintf("%s%d", ph.Prefix, i+1), v))
+	}
+	ph.values = ph.values[:0]
+	return
+}

--- a/dialect/sqlserver/main.go
+++ b/dialect/sqlserver/main.go
@@ -1,6 +1,8 @@
 package sqlserver
 
 import (
+	"time"
+
 	_ "github.com/microsoft/go-mssqldb"
 	_ "github.com/microsoft/go-mssqldb/namedpipe"
 	_ "github.com/microsoft/go-mssqldb/sharedmemory"
@@ -8,16 +10,54 @@ import (
 	"github.com/hymkor/sqlbless/dialect"
 )
 
-func sqlServerTypeNameToConv(typeName string) func(string) (any, error) {
-	switch typeName {
-	case "SMALLDATETIME", "DATETIME", "DATETIME2":
-		// SMALLDATETIME: YYYY-MM-DD hh:mm:ss
-		// 120: yyyy-mm-dd hh:mi:ss
-		return func(s string) (any, error) {
-			return dialect.ParseAnyDateTime(s)
-		}
+var typeSpec = map[string][2]string{
+	"DATE": {
+		"CAST(@v%d AS DATE)",
+		dialect.DateOnlyLayout},
+	"SMALLDATETIME": {
+		"CAST(@v%d AS SMALLDATETIME)",
+		dialect.ShortDateTimeLayout},
+	"DATETIME": {
+		"CAST(@v%d AS DATETIME)",
+		dialect.DateTimeLayout3p},
+	"DATETIME2": {
+		"CAST(@v%d AS DATETIME2)",
+		dialect.DateTimeLayout7p},
+	"DATETIMEOFFSET": {
+		"CAST(@v%d AS DATETIMEOFFSET)",
+		dialect.DateTimeTzLayout},
+	"TIME": {
+		"CAST(@v%d AS TIME)",
+		dialect.TimeOnlyLayout},
+}
+
+func typeNameToConv(typeName string) func(string) (any, error) {
+	spec, ok := typeSpec[typeName]
+	if !ok {
+		return nil
 	}
-	return nil
+	return func(s string) (any, error) {
+		dt, err := dialect.ParseAnyDateTime(s)
+		if err != nil {
+			return nil, err
+		}
+		return &dialect.SQLFmtAndValue{
+			Format: spec[0],
+			Value:  dt.Format(spec[1]),
+		}, nil
+	}
+}
+
+func formatValue(typeName string, value any) (string, bool) {
+	t, ok := value.(time.Time)
+	if !ok {
+		return "", false
+	}
+	spec, ok := typeSpec[typeName]
+	if !ok {
+		return "", false
+	}
+	return t.Format(spec[1]), true
 }
 
 var sqlServerSpec = &dialect.Entry{
@@ -43,10 +83,11 @@ var sqlServerSpec = &dialect.Entry{
 	   and c.user_type_id = t.user_type_id
 	 order by c.column_id`,
 	SQLForTables:     `select * from sys.tables`,
-	TypeConverterFor: sqlServerTypeNameToConv,
-	PlaceHolder:      &dialect.PlaceHolderName{Prefix: "@", Format: "v"},
+	TypeConverterFor: typeNameToConv,
+	PlaceHolder:      &dialect.PlaceHolderName{Mark: "@", Prefix: "v"},
 	TableNameField:   "name",
 	ColumnNameField:  "name",
+	FormatValue:      formatValue,
 }
 
 func init() {

--- a/test/test-sqlserver.ps1
+++ b/test/test-sqlserver.ps1
@@ -76,7 +76,7 @@ ForEach-Object {
         Write-Host $field[3]
         return
     }
-    if ( $field[4] -notlike "2027-03-04 11:12:00*" ){
+    if ( $field[4] -notlike "2027-03-04 11:12*" ){
         # SMALLDATETIME does not contain SECOND
         Write-Host $field[4]
         return


### PR DESCRIPTION
- Improved datetime handling in SELECT and EDIT operations. Columns without timezone information no longer display redundant timezone offsets, and fields without certain precision (such as seconds) no longer show unnecessary components. Datetime comparison and update matching are now performed using string representations appropriate for each column type. 
- Added support for SQL Server DATETIMEOFFSET columns in edit mode.
&nbsp;
- SELECT / EDIT における日時表示を改善。タイムゾーン情報を持たないカラムでは不要なタイムゾーン表示を行わないようにし、精度を持たない項目（例: 秒）も表示しないようにした。日時比較や更新時の照合も、各カラム型に応じた文字列形式で行うよう改善した。
- edit 文でSQL Server の DATETIMEOFFSET 型をサポートした