### PR TITLE
Refactor subpackages related to database (dialect/oracle and sqlite)

### DIFF
--- a/dialect/main.go
+++ b/dialect/main.go
@@ -82,6 +82,7 @@ const (
 	DateTimeLayout      = "2006-01-02 15:04:05.999999999"
 	DateTimeLayout7p    = "2006-01-02 15:04:05.0000000"
 	DateTimeLayout3p    = "2006-01-02 15:04:05.000"
+	DateTimeLayout0p    = "2006-01-02 15:04:05"
 	ShortDateTimeLayout = "2006-01-02 15:04"
 	DateOnlyLayout      = "2006-01-02"
 	TimeOnlyLayout      = "15:04:05.999999999"

--- a/dialect/main.go
+++ b/dialect/main.go
@@ -85,6 +85,7 @@ const (
 	DateTimeLayout0p    = "2006-01-02 15:04:05"
 	ShortDateTimeLayout = "2006-01-02 15:04"
 	DateOnlyLayout      = "2006-01-02"
+	TimeOnlyLayout0p    = "15:04:05"
 	TimeOnlyLayout      = "15:04:05.999999999"
 	TimeTzLayout        = "15:04:05.999999999 -07:00"
 	RawTimeLayout       = "2006-01-02T15:04:05Z"

--- a/dialect/oracle/main.go
+++ b/dialect/oracle/main.go
@@ -1,8 +1,6 @@
 package sqlbless
 
 import (
-	"database/sql"
-	"fmt"
 	"strings"
 	"time"
 
@@ -30,12 +28,17 @@ var oracleSpec = &dialect.Entry{
    where table_name = UPPER(:1)
    order by column_id`,
 	SQLForTables:     `select * from tab where tname not like 'BIN$%'`,
-	TypeConverterFor: oracleTypeNameToConv,
+	TypeConverterFor: typeNameToConv,
 	TableNameField:   "tname",
 	ColumnNameField:  "name",
-	PlaceHolder:      new(placeHolder),
+	PlaceHolder:      &dialect.PlaceHolderName{Mark: ":", Prefix: "v"},
 	FormatValue:      formatValue,
 }
+
+const (
+	timeStampTz  = "TimeStampTZ_DTY"
+	timeStampLtz = "TimeStampLTZ_DTY"
+)
 
 func formatValue(typeName string, value any) (string, bool) {
 	t, ok := value.(time.Time)
@@ -43,31 +46,26 @@ func formatValue(typeName string, value any) (string, bool) {
 		return "", false
 	}
 	if typeName == "DATE" {
-		return t.Format("2006-01-02 15:04:05"), true
+		return t.Format(dialect.DateTimeLayout0p), true
 	}
-	if strings.EqualFold(typeName, "TimeStampTZ_DTY") ||
-		strings.EqualFold(typeName, "TimeStampLTZ_DTY") {
+	if strings.EqualFold(typeName, timeStampTz) ||
+		strings.EqualFold(typeName, timeStampLtz) {
 
 		return t.Format("2006-01-02 15:04:05.999999 -07:00"), true
 	}
 	return t.Format("2006-01-02 15:04:05.999999"), true
 }
 
-type withFormat struct {
-	format string
-	value  any
-}
-
-func oracleTypeNameToConv(typeName string) func(string) (any, error) {
+func typeNameToConv(typeName string) func(string) (any, error) {
 	var format string
 	var layout string
 
 	if typeName == "DATE" {
 		format = "TO_DATE(:v%d,'YYYY-MM-DD HH24:MI:SS')"
-		layout = "2006-01-02 15:04:05"
+		layout = dialect.DateTimeLayout0p
 	} else if strings.HasPrefix(typeName, "TIMESTAMP") {
-		if strings.EqualFold(typeName, "TimeStampTZ_DTY") ||
-			strings.EqualFold(typeName, "TimeStampLTZ_DTY") {
+		if strings.EqualFold(typeName, timeStampTz) ||
+			strings.EqualFold(typeName, timeStampLtz) {
 
 			format = "TO_TIMESTAMP_TZ(:v%d,'YYYY-MM-DD HH24:MI:SS.FF TZH:TZM')"
 			layout = "2006-01-02 15:04:05.999999 -07:00"
@@ -83,36 +81,11 @@ func oracleTypeNameToConv(typeName string) func(string) (any, error) {
 		if err != nil {
 			return s, nil
 		}
-		return &withFormat{
-			format: format,
-			value:  dt.Format(layout),
+		return &dialect.SQLFmtAndValue{
+			Format: format,
+			Value:  dt.Format(layout),
 		}, nil
 	}
-}
-
-type placeHolder struct {
-	values []any
-}
-
-func (ph *placeHolder) Make(v any) string {
-	if w, ok := v.(*withFormat); ok {
-		ph.values = append(ph.values, w.value)
-		return fmt.Sprintf(w.format, len(ph.values))
-	}
-	ph.values = append(ph.values, v)
-	return fmt.Sprintf(":v%d", len(ph.values))
-}
-
-func (ph *placeHolder) NormalizeColumnForWhere(value any, columnName string) string {
-	return columnName
-}
-
-func (ph *placeHolder) Values() (result []any) {
-	for i, v := range ph.values {
-		result = append(result, sql.Named(fmt.Sprintf("v%d", i+1), v))
-	}
-	ph.values = ph.values[:0]
-	return
 }
 
 func init() {

--- a/dialect/sqlite/main.go
+++ b/dialect/sqlite/main.go
@@ -35,14 +35,8 @@ var Entry = &dialect.Entry{
 
 func formatValue(typeName string, value any) (string, bool) {
 	if t, ok := value.(time.Time); ok {
-		if typeName == "DATE" {
-			return t.Format("2006-01-02"), true
-		}
-		if typeName == "DATETIME" {
-			return t.Format("2006-01-02 15:04:05"), true
-		}
-		if typeName == "TIMESTAMP" {
-			return t.Format("2006-01-02 15:04:05.999999999"), true
+		if spec, ok := typeNameToHolder[typeName]; ok {
+			return t.Format(spec[1]), true
 		}
 	}
 	return "", false
@@ -56,17 +50,17 @@ func canUseInTransaction(sql string) bool {
 
 var typeNameToHolder = map[string][2]string{
 	"TIMESTAMP": [2]string{
-		"strftime('%Y-%m-%d %H:%M:%f',?)", // "2006-01-02 15:04:05.999999999-07:00"
-		"2006-01-02 15:04:05.999999999"},
+		"strftime('%Y-%m-%d %H:%M:%f',?)",
+		dialect.DateTimeLayout},
 	"TIME": [2]string{
-		"time(?)", // dialect.TimeOnlyLayout
-		"15:04:05"},
+		"time(?)",
+		dialect.TimeOnlyLayout0p},
 	"DATE": [2]string{
-		"date(?)", // dialect.DateOnlyLayout
-		"2006-01-02"},
+		"date(?)",
+		dialect.DateOnlyLayout},
 	"DATETIME": [2]string{
-		"datetime(?)", // dialect.DateTimeLayout
-		"2006-01-02 15:04:05"},
+		"datetime(?)",
+		dialect.DateTimeLayout0p},
 }
 
 func typeNameToConv(typeName string) func(string) (any, error) {
@@ -76,18 +70,13 @@ func typeNameToConv(typeName string) func(string) (any, error) {
 			if err != nil {
 				return s, nil
 			}
-			return &withHolder{
-				holder: holder[0],
-				value:  dt.Format(holder[1]),
+			return &dialect.SQLFmtAndValue{
+				Format: holder[0],
+				Value:  dt.Format(holder[1]),
 			}, nil
 		}
 	}
 	return nil
-}
-
-type withHolder struct {
-	holder string
-	value  any
 }
 
 type placeHolder struct {
@@ -95,17 +84,17 @@ type placeHolder struct {
 }
 
 func (ph *placeHolder) Make(v any) string {
-	if w, ok := v.(*withHolder); ok {
-		ph.values = append(ph.values, w.value)
-		return strings.ReplaceAll(w.holder, "?", fmt.Sprintf("$v%d", len(ph.values)))
+	if w, ok := v.(*dialect.SQLFmtAndValue); ok {
+		ph.values = append(ph.values, w.Value)
+		return strings.ReplaceAll(w.Format, "?", fmt.Sprintf("$v%d", len(ph.values)))
 	}
 	ph.values = append(ph.values, v)
 	return fmt.Sprintf("$v%d", len(ph.values))
 }
 
 func (ph *placeHolder) NormalizeColumnForWhere(value any, columnName string) string {
-	if w, ok := value.(*withHolder); ok {
-		return strings.ReplaceAll(w.holder, "?", columnName)
+	if w, ok := value.(*dialect.SQLFmtAndValue); ok {
+		return strings.ReplaceAll(w.Format, "?", columnName)
 	}
 	return columnName
 }


### PR DESCRIPTION
- Refactor subpackages related to database
  - Use constants in "dialect" subpackege as possible
  - Use placeholder structures in "dialect" subpackege
&nbsp;
- DB 関連のサブパッケージ（dialect/oracle, sqlite）をリファクタリング
  - 定数は、なるべく dialect のもので共通化
  - PlaceHolder 用構造体も dialect のものを使用