### PR TITLE
In MySQL, `desc` supports `desc {schema}.{table}` syntax now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog (English)
 - Improved datetime handling in SELECT and EDIT operations. Columns without timezone information no longer display redundant timezone offsets, and fields without certain precision (such as seconds) no longer show unnecessary components. Datetime comparison and update matching are now performed using string representations appropriate for each column type. Supported for Oracle, PostgreSQL, SQLite, and SQL Server. (#55, #57, #58, #65, #66)
 - Improved readability of datetime values shown in bind variable output during edit operations. (#60)
 - Added support for Oracle TIMESTAMP WITH TIME ZONE / TIMESTAMP WITH LOCAL TIME ZONE and SQL Server DATETIMEOFFSET columns in edit mode. (#63, #66)
+- In MySQL, `desc` supports `desc {schema}.{table}` syntax now (#68)
 
 v0.27.7
 -------

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -10,6 +10,7 @@ Changelog (Japanese)
 - SELECT / EDIT における日時表示を改善。タイムゾーン情報を持たないカラムでは不要なタイムゾーン表示を行わないようにし、精度を持たない項目（例: 秒）も表示しないようにした。日時比較や更新時の照合も、各カラム型に応じた文字列形式で行うよう改善した。Oracle / PostgreSQL / SQLite / SQL Server に対応。 (#55, #57, #58, #65, #66)
 - edit 文のバインド変数出力における日時表示の読み易さを改善した。 (#60)
 - edit 文で Oracle TIMESTAMP WITH TIME ZONE / TIMESTAMP WITH LOCAL TIME ZONE および SQL Server DATETIMEOFFSET 型をサポートした。 (#63, #66)
+- MySQL の desc 文で `desc {スキーマ名}.{テーブル名}` をサポート (#68)
 
 v0.27.7
 -------

--- a/dialect/mysql/main.go
+++ b/dialect/mysql/main.go
@@ -80,21 +80,29 @@ var mySqlSpec = &dialect.Entry{
                  else 'NOT NULL'
                end as "NULL?"
           from information_schema.columns
-         where table_name = ?
+          join (select ? as x) v
+         where table_name   = REGEXP_REPLACE(v.x,'^[^\\.]*\\.','')
+           and table_schema =
+               case
+                 when instr(v.x,'.') >= 1 then
+                      regexp_replace(v.x,'\\.[^\\.]*$','')
+                 else database()
+               end
          order by ordinal_position`,
 	SQLForTables: `
-        select * from information_schema.tables
+        select concat(table_schema,'.',table_name) as FULL_NAME,
+               tables.* from information_schema.tables
          where table_type = 'BASE TABLE'
            and table_schema 
         not in ('mysql', 'information_schema', 'performance_schema', 'sys')`,
 	TypeConverterFor: mySQLTypeNameToConv,
 	PlaceHolder:      &dialect.PlaceHolderQuestion{},
 	DSNFilter:        mySQLDSNFilter,
-	TableNameField:   "TABLE_NAME",
+	TableNameField:   "FULL_NAME",
 	ColumnNameField:  "NAME",
 
 	IdentifierEncloser: func(s string) string {
-		return "`" + s + "`"
+		return "`" + strings.ReplaceAll(s, ".", "`.`") + "`"
 	},
 }
 


### PR DESCRIPTION
- In MySQL, `desc` supports `desc {schema}.{table}` syntax now
&nbsp;
- MySQL の desc 文で `desc {スキーマ名}.{テーブル名}` をサポート