### PR TITLE
`edit`: Handle MySQL datetime values as wall-clock strings without timezone information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Changelog (English)
   - Upgrade MySQL driver to v1.10.0
   - Upgrade Microsoft SQL Server driver to v1.10.0
   - Upgrade PostgreSQL driver to v1.12.3
-- Improved datetime handling in SELECT and EDIT operations. Columns without timezone information no longer display redundant timezone offsets, and fields without certain precision (such as seconds) no longer show unnecessary components. Datetime comparison and update matching are now performed using string representations appropriate for each column type. Supported for Oracle, PostgreSQL, SQLite, and SQL Server. (#55, #57, #58, #65, #66)
+- Improved datetime handling in SELECT and EDIT operations. Columns without timezone information no longer display redundant timezone offsets, and fields without certain precision (such as seconds) no longer show unnecessary components. Datetime comparison and update matching are now performed using string representations appropriate for each column type. (#55, #57, #58, #65, #66, #69)
 - Improved readability of datetime values shown in bind variable output during edit operations. (#60)
 - Added support for Oracle TIMESTAMP WITH TIME ZONE / TIMESTAMP WITH LOCAL TIME ZONE and SQL Server DATETIMEOFFSET columns in edit mode. (#63, #66)
 - In MySQL, `desc` supports `desc {schema}.{table}` syntax now (#68)

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -7,7 +7,7 @@ Changelog (Japanese)
   - Upgrade MySQL driver to v1.10.0
   - Upgrade Microsoft SQL Server driver to v1.10.0
   - Upgrade PostgreSQL driver to v1.12.3
-- SELECT / EDIT における日時表示を改善。タイムゾーン情報を持たないカラムでは不要なタイムゾーン表示を行わないようにし、精度を持たない項目（例: 秒）も表示しないようにした。日時比較や更新時の照合も、各カラム型に応じた文字列形式で行うよう改善した。Oracle / PostgreSQL / SQLite / SQL Server に対応。 (#55, #57, #58, #65, #66)
+- SELECT / EDIT における日時表示を改善。タイムゾーン情報を持たないカラムでは不要なタイムゾーン表示を行わないようにし、精度を持たない項目（例: 秒）も表示しないようにした。日時比較や更新時の照合も、各カラム型に応じた文字列形式で行うよう改善した。(#55, #57, #58, #65, #66, #69)
 - edit 文のバインド変数出力における日時表示の読み易さを改善した。 (#60)
 - edit 文で Oracle TIMESTAMP WITH TIME ZONE / TIMESTAMP WITH LOCAL TIME ZONE および SQL Server DATETIMEOFFSET 型をサポートした。 (#63, #66)
 - MySQL の desc 文で `desc {スキーマ名}.{テーブル名}` をサポート (#68)

--- a/dialect/mysql/main.go
+++ b/dialect/mysql/main.go
@@ -3,6 +3,7 @@ package sqlbless
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	_ "github.com/go-sql-driver/mysql"
 
@@ -11,27 +12,23 @@ import (
 
 var mySQLTypeNameToFormat = map[string]string{
 	"DATETIME":  dialect.DateTimeLayout,
-	"TIMESTAMP": "2006-01-02 15:04:05.999999999-07:00",
+	"TIMESTAMP": "2006-01-02 15:04:05.999999999-07:00", // no space before tz
 	"TIME":      dialect.TimeOnlyLayout,
 	"DATE":      dialect.DateOnlyLayout,
 }
 
-func mySQLTypeNameToConv(typeName string) func(string) (any, error) {
-	if typeName == "TIME" {
-		return func(s string) (any, error) {
-			tm, err := dialect.ParseAnyDateTime(s)
-			if err != nil {
-				return nil, err
-			}
-			return tm.Format("15:04:05.999999999"), nil
-		}
+func typeNameToConv(typeName string) func(string) (any, error) {
+	f, ok := mySQLTypeNameToFormat[typeName]
+	if !ok {
+		return nil
 	}
-	if _, ok := mySQLTypeNameToFormat[typeName]; ok {
-		return func(s string) (any, error) {
-			return dialect.ParseAnyDateTime(s)
+	return func(s string) (any, error) {
+		t, err := dialect.ParseAnyDateTime(s)
+		if err != nil {
+			return nil, err
 		}
+		return t.Format(f), nil
 	}
-	return nil
 }
 
 func mySQLDSNFilter(dsn string) (string, error) {
@@ -61,6 +58,23 @@ func mySQLDSNFilter(dsn string) (string, error) {
 		}
 	}
 	return newdsn.String(), nil
+}
+
+func formatValue(typeName string, value any) (string, bool) {
+	t, ok := value.(time.Time)
+	if !ok {
+		return "", false
+	}
+	switch typeName {
+	case "DATE":
+		return t.Format(dialect.DateOnlyLayout), true
+	case "TIME":
+		return t.Format(dialect.TimeOnlyLayout), true
+	case "DATETIME", "TIMESTAMP":
+		return t.Format(dialect.DateTimeLayout), true
+	default:
+		return "", false
+	}
 }
 
 var mySqlSpec = &dialect.Entry{
@@ -95,7 +109,7 @@ var mySqlSpec = &dialect.Entry{
          where table_type = 'BASE TABLE'
            and table_schema 
         not in ('mysql', 'information_schema', 'performance_schema', 'sys')`,
-	TypeConverterFor: mySQLTypeNameToConv,
+	TypeConverterFor: typeNameToConv,
 	PlaceHolder:      &dialect.PlaceHolderQuestion{},
 	DSNFilter:        mySQLDSNFilter,
 	TableNameField:   "FULL_NAME",
@@ -104,6 +118,7 @@ var mySqlSpec = &dialect.Entry{
 	IdentifierEncloser: func(s string) string {
 		return "`" + strings.ReplaceAll(s, ".", "`.`") + "`"
 	},
+	FormatValue: formatValue,
 }
 
 func init() {


### PR DESCRIPTION
- Improved datetime handling in SELECT and EDIT operations. Columns without timezone information no longer display redundant timezone offsets, and fields without certain precision (such as seconds) no longer show unnecessary components. Datetime comparison and update matching are now performed using string representations appropriate for each column type. 
&nbsp;
- SELECT / EDIT における日時表示を改善。タイムゾーン情報を持たないカラムでは不要なタイムゾーン表示を行わないようにし、精度を持たない項目（例: 秒）も表示しないようにした。日時比較や更新時の照合も、各カラム型に応じた文字列形式で行うよう改善した。