### PR TITLE
Simplify run.cmd

### DIFF
--- a/run.cmd
+++ b/run.cmd
@@ -1,34 +1,29 @@
-@setlocal
-@set PROMPT=$G$S
-@call :"%~1" %2 %3 %4 %5 %6 %7 %8 %9
-@endlocal
-@exit /b
+@echo off
+call :"%~1" %2 %3 %4 %5 %6 %7 %8 %9
+exit /b
+
+:""
+echo run.cmd {sqlite^|sqlserver^|mysql^|oracle^|psql}
+exit /b
 
 :"sqlite"
 :"sqlite3"
 sqlbless %* sqlite3 mytestdb
-@exit /b
+exit /b
 
 :"mssql"
 :"sqlserver"
-sqlbless %* sqlserver "Server=localhost\SQLEXPRESS;Database=master;Trusted_Connection=True;protocol=lpc;"
-@exit /b
+sqlbless %* "sqlserver://@localhost/SQLExpress?Database=master&protocol=lpc"
+exit /b
 
 :"mysql"
 sqlbless %* mysql "root:@/mydb"
-@exit /b
+exit /b
 
 :"oracle"
 sqlbless %* oracle://scott:tiger@localhost:1521/xepdb1
-@exit /b
+exit /b
 
 :"psql"
-@rem Driver: https://github.com/lib/pq
-@rem Schema postgresql://${username}:${password}@localhost:${port}/${database}?options=--search_path%3D${schema}"
-sqlbless %* postgres://postgres@127.0.0.1:5432/chinook?sslmode=disable
-@exit /b
-
-:"-psql"
-psql -h 127.0.0.1 -p 5432 -d postgres -U postgres
-@exit /b
-
+sqlbless %* postgres://postgres@127.0.0.1:5432/postgres?sslmode=disable
+exit /b


### PR DESCRIPTION
## Changes in this PR (English)

Simplified the sample launcher script `run.cmd` to improve readability.

* Added usage help when no arguments are specified
* Removed extra features such as launching `psql.exe`
* Removed comments preserving old pre-refactoring code
* Replaced prompt customization and selective echo tricks with a straightforward `@echo off`
* Changed the PostgreSQL connection target from the `chinook` database to the default database
  * If you want to use the Chinook sample database, please use:
    https://gist.github.com/hymkor/e3769517c8a61160b1a92e9a87275473
* Simplified the SQL Server connection parameters by switching to a URL-style format and removing redundant settings

## Changes in this PR(Japanese)

起動サンプル用のバッチファイル run.cmd をシンプルにして、読みやすくしました。

- 引数なしの時に説明を表示するようにした
- psql.exe を起動するといった余計な機能を削除
- 過去の修正前の状態を残すコメントを削除
- 素直に `@echo off` を入れて、プロンプトを変えたり、必要なところだけエコーバックするような読みづらい小細工を削除
- PostgreSQL の接続先で chinook database になっていたところがあったので、デフォルトデータベースに寄せた。
  （ chinook database を使いたい場合は、https://gist.github.com/hymkor/e3769517c8a61160b1a92e9a87275473 をご利用ください）
- SQL Server と接続する際のパラメータを URL 風にして、冗長なパラメータも削減した