### PR TITLE
Stop appending `parseTime=true&loc=Local` to MySQL DSNs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog (English)
 - Improved readability of datetime values shown in bind variable output during edit operations. (#60)
 - Added support for Oracle TIMESTAMP WITH TIME ZONE / TIMESTAMP WITH LOCAL TIME ZONE and SQL Server DATETIMEOFFSET columns in edit mode. (#63, #66)
 - In MySQL, `desc` supports `desc {schema}.{table}` syntax now (#68)
+- Since the `edit` command now handles date/time values primarily as strings, SQL-Bless no longer needs to force MySQL drivers to return `time.Time` values. As a result, SQL-Bless no longer appends `&parseTime=true&loc=Local` to MySQL DSNs. (#71)
 
 v0.27.7
 -------

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -11,6 +11,7 @@ Changelog (Japanese)
 - edit 文のバインド変数出力における日時表示の読み易さを改善した。 (#60)
 - edit 文で Oracle TIMESTAMP WITH TIME ZONE / TIMESTAMP WITH LOCAL TIME ZONE および SQL Server DATETIMEOFFSET 型をサポートした。 (#63, #66)
 - MySQL の desc 文で `desc {スキーマ名}.{テーブル名}` をサポート (#68)
+- `edit` 文で日時をあくまで文字列ベースで扱うようにした結果、time.Time の使用を MySQL ドライバーパッケージに指定する必要がなくなったため、`&parseTime=True&loc=Local` を DSN 文字列に追記するのをやめた (#71)
 
 v0.27.7
 -------

--- a/README.md
+++ b/README.md
@@ -215,7 +215,6 @@ DRIVERNAME can be omitted when DATASOURCENAME contains DRIVERNAME.
     $ sqlbless.exe mysql user:password@/database
 
 - The driver used is http://github.com/go-sql-driver/mysql
-- The `?parseTime=true&loc=Local` parameter is preset, but it can be overridden
 - [Example startup batch file](./examples/run-mysql.cmd)
 
 Common Options

--- a/README_ja.md
+++ b/README_ja.md
@@ -216,7 +216,6 @@ DRIVERNAME は、DATASOURCENAME の中に含まれている場合は省略可能
     $ sqlbless.exe mysql user:password@/database
 
 - 使用ドライバー http://github.com/go-sql-driver/mysql
-- パラメータ `?parseTime=true&loc=Local` が予め設定されていますが、上書き可能です
 - [起動バッチファイル例](./examples/run-mysql.cmd)
 
 共通オプション

--- a/dialect/main.go
+++ b/dialect/main.go
@@ -102,29 +102,41 @@ var (
 )
 
 func ParseAnyDateTime(s string) (time.Time, error) {
+	_, t, err := ParseAnyDateTimeX(s)
+	return t, err
+}
+
+func ParseAnyDateTimeX(s string) (string, time.Time, error) {
 	if m := rxDateTimeTz.FindStringSubmatch(s); m != nil {
-		return time.Parse(DateTimeTzLayout,
+		t, err := time.Parse(DateTimeTzLayout,
 			fmt.Sprintf("%s %s%02s:%02s", m[1], m[2], m[3], m[4]))
+		return DateTimeTzLayout, t, err
 	}
 	if m := rxDateTime.FindStringSubmatch(s); m != nil {
-		return time.ParseInLocation(DateTimeLayout, m[1], time.Local)
+		t, err := time.ParseInLocation(DateTimeLayout, m[1], time.Local)
+		return DateTimeLayout, t, err
 	}
 	if m := rxDateOnly.FindStringSubmatch(s); m != nil {
-		return time.Parse(DateOnlyLayout, m[1])
+		t, err := time.Parse(DateOnlyLayout, m[1])
+		return DateOnlyLayout, t, err
 	}
 	if m := rxShortDateTime.FindStringSubmatch(s); m != nil {
-		return time.ParseInLocation(ShortDateTimeLayout, m[1], time.Local)
+		t, err := time.ParseInLocation(ShortDateTimeLayout, m[1], time.Local)
+		return ShortDateTimeLayout, t, err
 	}
 	if m := rxTimeTz.FindStringSubmatch(s); m != nil {
-		return time.Parse(TimeTzLayout, m[1])
+		t, err := time.Parse(TimeTzLayout, m[1])
+		return TimeTzLayout, t, err
 	}
 	if m := rxTimeOnly.FindStringSubmatch(s); m != nil {
-		return time.ParseInLocation(TimeOnlyLayout, m[1], time.Local)
+		t, err := time.ParseInLocation(TimeOnlyLayout, m[1], time.Local)
+		return TimeOnlyLayout, t, err
 	}
 	if m := rxRawLayout.FindStringSubmatch(s); m != nil {
-		return time.Parse(RawTimeLayout, m[1])
+		t, err := time.Parse(RawTimeLayout, m[1])
+		return RawTimeLayout, t, err
 	}
-	return time.Time{}, fmt.Errorf("%w: %s", ErrNotTimeFormat, s)
+	return "", time.Time{}, fmt.Errorf("%w: %s", ErrNotTimeFormat, s)
 }
 
 var registry = map[string]*Entry{}

--- a/dialect/main.go
+++ b/dialect/main.go
@@ -43,9 +43,6 @@ type Entry struct {
 	// The returned function converts a string literal to the corresponding Go value.
 	TypeConverterFor func(typeName string) func(literal string) (any, error)
 
-	// DSNFilter adjusts or validates a given DSN string before use.
-	DSNFilter func(dsn string) (string, error)
-
 	// IsTransactionSafe reports whether the given SQL statement is safe to run in a transaction.
 	IsTransactionSafe func(sql string) bool
 
@@ -194,11 +191,6 @@ func ReadDBInfoFromArgs(args []string) (*DBInfo, error) {
 		Driver:     args[0],
 		DataSource: args[1],
 		Dialect:    entry,
-	}
-	if entry.DSNFilter != nil {
-		if d.DataSource, err = entry.DSNFilter(d.DataSource); err != nil {
-			return nil, err
-		}
 	}
 	return d, nil
 }

--- a/dialect/mysql/main.go
+++ b/dialect/mysql/main.go
@@ -1,7 +1,6 @@
 package sqlbless
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
@@ -10,9 +9,13 @@ import (
 	"github.com/hymkor/sqlbless/dialect"
 )
 
+const (
+	mySQLDateTimeTzLayout = "2006-01-02 15:04:05.999999999-07:00"
+)
+
 var mySQLTypeNameToFormat = map[string]string{
 	"DATETIME":  dialect.DateTimeLayout,
-	"TIMESTAMP": "2006-01-02 15:04:05.999999999-07:00", // no space before tz
+	"TIMESTAMP": dialect.DateTimeLayout,
 	"TIME":      dialect.TimeOnlyLayout,
 	"DATE":      dialect.DateOnlyLayout,
 }
@@ -23,41 +26,16 @@ func typeNameToConv(typeName string) func(string) (any, error) {
 		return nil
 	}
 	return func(s string) (any, error) {
-		t, err := dialect.ParseAnyDateTime(s)
+		typ, t, err := dialect.ParseAnyDateTimeX(s)
 		if err != nil {
 			return nil, err
 		}
+		if typ == dialect.DateTimeTzLayout {
+			// for parseTime=true
+			return t.Format(mySQLDateTimeTzLayout), nil
+		}
 		return t.Format(f), nil
 	}
-}
-
-func mySQLDSNFilter(dsn string) (string, error) {
-	base, param, ok := strings.Cut(dsn, "?")
-	hash := make(map[string][]string)
-	if ok {
-		for _, pair := range strings.Split(param, "&") {
-			left, right, ok := strings.Cut(pair, "=")
-			if ok {
-				hash[left] = append(hash[left], right)
-			}
-		}
-	}
-	if _, ok := hash["parseTime"]; !ok {
-		hash["parseTime"] = []string{"true"}
-	}
-	if _, ok := hash["loc"]; !ok {
-		hash["loc"] = []string{"Local"}
-	}
-	var newdsn strings.Builder
-	newdsn.WriteString(base)
-	delimiter := '?'
-	for key, values := range hash {
-		for _, v := range values {
-			fmt.Fprintf(&newdsn, "%c%s=%s", delimiter, key, v)
-			delimiter = '&'
-		}
-	}
-	return newdsn.String(), nil
 }
 
 func formatValue(typeName string, value any) (string, bool) {
@@ -111,7 +89,6 @@ var mySqlSpec = &dialect.Entry{
         not in ('mysql', 'information_schema', 'performance_schema', 'sys')`,
 	TypeConverterFor: typeNameToConv,
 	PlaceHolder:      &dialect.PlaceHolderQuestion{},
-	DSNFilter:        mySQLDSNFilter,
 	TableNameField:   "FULL_NAME",
 	ColumnNameField:  "NAME",
 

--- a/test/test-mysql.ps1
+++ b/test/test-mysql.ps1
@@ -22,6 +22,7 @@ $script = `
     "COMMIT||" +
     "EDIT TESTTBL||" +
     "/10|lr2015-06-07 20:21:22.123+09:00|lr2016-07-08|lr15:54:27.345|qyy" +
+    "SET TIME_ZONE='+09:00'||" +
     "SPOOL $testLst||" +
     "SELECT * FROM TESTTBL||" +
     "SPOOL OFF ||" +
@@ -55,15 +56,15 @@ ForEach-Object {
         Write-Host "NG:" $field.Length
         return
     }
-    if ( $field[1] -ne "2015-06-07 20:21:22.123 +09:00" ){
+    if ( $field[1] -ne "2015-06-07 20:21:22.123" ){
         Write-Host "NG:" $field[1]
         return
     }
-    if ( $field[2] -notlike "2016-07-08*" ){
+    if ( $field[2] -ne "2016-07-08" ){
         Write-Host "NG:" $field[2]
         return
     }
-    if ( $field[3] -notlike "*15:54:27.345" ){
+    if ( $field[3] -ne "15:54:27.345" ){
         Write-Host "NG:" $field[3]
         return
     }


### PR DESCRIPTION
- Add dialect.ParseAnyDateTimeX returning matched layout  
  （いろんなパターンの日時文字列を自動判断して time.Time へ変換する関数として、ParseAnyDateTime を用意していたが、どういう日時文字列由来か、呼び出し元から分からなかった。MySQL 対応で、ユーザが明示的にタイムゾーンオフセットを指定した場合、それを尊重するため、タイムゾーンオフセットの有無を判別できるよう、time.Parse を使った時に用いたレイアウト文字列もあわせて返す関数：ParseAnyDateTimeX を作成した）
- **Stop appending `parseTime=true&loc=Local` to MySQL DSNs**
  （edit 文で日時をあくまで文字列ベースで扱うようにした結果、time.Time の使用を MySQL ドライバーパッケージに指定する必要がなくなったため、&parseTime=True&loc=Local を DSN 文字列に追記するのをやめた）
- Set MySQL session time zone in tests to stabilize TIMESTAMP comparisons
  （サーバー時刻を UTC にすると、テストが失敗してしまう問題を修正）
- Remove `DSNFilter` field from dialect.Entry
 （今回の修正で、DSN の加工する仕組み自体が不要となってしまったので、加工関数を登録するためのフィールドを DB 方言を管理する構造体から消した）
- README: Remove description of automatic MySQL DSN modification
  （READMEから、parseTime などを DSN に追加している旨の説明を削除）