### PR TITLE
PostgreSQL: show all accessible tables in edit selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog (English)
 - Added support for Oracle TIMESTAMP WITH TIME ZONE / TIMESTAMP WITH LOCAL TIME ZONE and SQL Server DATETIMEOFFSET columns in edit mode. (#63, #66)
 - In MySQL, `desc` supports `desc {schema}.{table}` syntax now (#68)
 - Since the `edit` command now handles date/time values primarily as strings, SQL-Bless no longer needs to force MySQL drivers to return `time.Time` values. As a result, SQL-Bless no longer appends `&parseTime=true&loc=Local` to MySQL DSNs. (#71)
+- PostgreSQL: Improved table selection for the edit command. All accessible tables are now available as candidates, including those in `pg_catalog` and `information_schema`. System tables are listed after user tables, and schema-qualified names (schema.table) are displayed to avoid ambiguity. (#72)
 
 v0.27.7
 -------

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -12,6 +12,7 @@ Changelog (Japanese)
 - edit 文で Oracle TIMESTAMP WITH TIME ZONE / TIMESTAMP WITH LOCAL TIME ZONE および SQL Server DATETIMEOFFSET 型をサポートした。 (#63, #66)
 - MySQL の desc 文で `desc {スキーマ名}.{テーブル名}` をサポート (#68)
 - `edit` 文で日時をあくまで文字列ベースで扱うようにした結果、time.Time の使用を MySQL ドライバーパッケージに指定する必要がなくなったため、`&parseTime=True&loc=Local` を DSN 文字列に追記するのをやめた (#71)
+- PostgreSQL で edit コマンドでのテーブル選択を改善した。`pg_catalog` と `information_schema` も含め、アクセスできる全テーブルを候補にできるようにした。システムテーブルはユーザテーブルの後でリストするようにし、あいまいにならないようにスキーマ修飾子(schema.table)も表示するようにした (#72)
 
 v0.27.7
 -------

--- a/dialect/main.go
+++ b/dialect/main.go
@@ -64,7 +64,7 @@ func (D *Entry) EncloseIdentifier(name string) string {
 	if f := D.IdentifierEncloser; f != nil {
 		return f(name)
 	}
-	return `"` + name + `"`
+	return `"` + strings.ReplaceAll(name, `.`, `"."`) + `"`
 }
 
 func (D *Entry) LookupConverter(typeName string) func(string) (any, error) {

--- a/dialect/postgresql/main.go
+++ b/dialect/postgresql/main.go
@@ -65,13 +65,16 @@ var postgresSpec = &dialect.Entry{
          and a.attisdropped is false
        order by a.attnum`,
 	SQLForTables: `
-      select *
+      select tables.table_schema || '.' || table_name as full_name,tables.*
         from information_schema.tables
        where table_type = 'BASE TABLE'
-         and table_schema not in ('pg_catalog', 'information_schema')`,
+	   order by case table_schema
+	    when 'pg_catalog' then 9
+		when 'information_schema' then 8
+		else 0 end`,
 	TypeConverterFor:  postgresTypeNameToConv,
 	PlaceHolder:       &placeHolder{},
-	TableNameField:    "table_name",
+	TableNameField:    "full_name",
 	ColumnNameField:   "name",
 	IsTransactionSafe: canUseInTransaction,
 	FormatValue:       formatValue,


### PR DESCRIPTION
Previously, tables in pg_catalog and information_schema were excluded from the edit target list. These tables are now included, but sorted after user tables.

The selection list now displays schema-qualified table names (schema.table) instead of table names alone.
&nbsp;
- PostgreSQL: Improved table selection for the edit command. All accessible tables are now available as candidates, including those in `pg_catalog` and `information_schema`. System tables are listed after user tables, and schema-qualified names (schema.table) are displayed to avoid ambiguity.
&nbsp;
- PostgreSQL で edit コマンドでのテーブル選択を改善した。`pg_catalog` と `information_schema` も含め、アクセスできる全テーブルを候補にできるようにした。システムテーブルはユーザテーブルの後でリストするようにし、あいまいにならないようにスキーマ修飾子(schema.table)も表示するようにした
