### PR TITLE
Refactor: "dialect/*": move SQLs from main.go to *.sql using "embed"

### DIFF
--- a/dialect/mysql/columns.sql
+++ b/dialect/mysql/columns.sql
@@ -1,0 +1,22 @@
+select  ordinal_position as "ID",
+        column_name as "NAME",
+        case
+            when character_maximum_length is not null then 
+                 concat(data_type,'(',character_maximum_length,')')
+            when datetime_precision is not null then
+                 concat(data_type,'(',datetime_precision,')')
+        else
+            data_type
+        end as "TYPE",
+        case is_nullable
+            when "YES" then 'NULL'
+            else 'NOT NULL'
+        end as "NULL?"
+  from  information_schema.columns,
+        (select ? as v1) arg
+ where  table_name   = REGEXP_REPLACE(v1,'^[^\\.]*\\.','')
+   and  table_schema = case
+            when v1 like '%.%' then regexp_replace(v1,'\\.[^\\.]*$','')
+            else database()
+        end
+ order  by ordinal_position

--- a/dialect/mysql/main.go
+++ b/dialect/mysql/main.go
@@ -1,6 +1,7 @@
 package sqlbless
 
 import (
+	_ "embed"
 	"strings"
 	"time"
 
@@ -12,6 +13,12 @@ import (
 const (
 	mySQLDateTimeTzLayout = "2006-01-02 15:04:05.999999999-07:00"
 )
+
+//go:embed tables.sql
+var tablesSql string
+
+//go:embed columns.sql
+var columnsSql string
 
 var mySQLTypeNameToFormat = map[string]string{
 	"DATETIME":  dialect.DateTimeLayout,
@@ -56,37 +63,9 @@ func formatValue(typeName string, value any) (string, bool) {
 }
 
 var mySqlSpec = &dialect.Entry{
-	Usage: `sqlbless mysql <USERNAME>:<PASSWORD>@/<DBNAME>`,
-	SQLForColumns: `
-        select ordinal_position as "ID",
-               column_name as "NAME",
-               case
-                 when character_maximum_length is not null then 
-                      concat(data_type,'(',character_maximum_length,')')
-                 when datetime_precision is not null then
-                      concat(data_type,'(',datetime_precision,')')
-                 else data_type
-               end as "TYPE",
-               case is_nullable
-                 when "YES" then 'NULL'
-                 else 'NOT NULL'
-               end as "NULL?"
-          from information_schema.columns
-          join (select ? as x) v
-         where table_name   = REGEXP_REPLACE(v.x,'^[^\\.]*\\.','')
-           and table_schema =
-               case
-                 when instr(v.x,'.') >= 1 then
-                      regexp_replace(v.x,'\\.[^\\.]*$','')
-                 else database()
-               end
-         order by ordinal_position`,
-	SQLForTables: `
-        select concat(table_schema,'.',table_name) as FULL_NAME,
-               tables.* from information_schema.tables
-         where table_type = 'BASE TABLE'
-           and table_schema 
-        not in ('mysql', 'information_schema', 'performance_schema', 'sys')`,
+	Usage:            `sqlbless mysql <USERNAME>:<PASSWORD>@/<DBNAME>`,
+	SQLForColumns:    columnsSql,
+	SQLForTables:     tablesSql,
 	TypeConverterFor: typeNameToConv,
 	PlaceHolder:      &dialect.PlaceHolderQuestion{},
 	TableNameField:   "FULL_NAME",

--- a/dialect/mysql/tables.sql
+++ b/dialect/mysql/tables.sql
@@ -1,0 +1,5 @@
+select  concat(table_schema,'.',table_name) as FULL_NAME,
+        tables.*
+  from  information_schema.tables
+ where  table_type = 'BASE TABLE'
+   and  table_schema not in ('mysql', 'information_schema', 'performance_schema', 'sys')

--- a/dialect/oracle/main.go
+++ b/dialect/oracle/main.go
@@ -10,13 +10,16 @@ import (
 	"github.com/hymkor/sqlbless/dialect"
 )
 
+//go:embed tables.sql
+var tablesSql string
+
 //go:embed columns.sql
 var columnsSql string
 
 var oracleSpec = &dialect.Entry{
 	Usage:            "sqlbless oracle://<USERNAME>:<PASSWORD>@<HOSTNAME>:<PORT>/<SERVICE>",
 	SQLForColumns:    columnsSql,
-	SQLForTables:     `select * from tab where tname not like 'BIN$%'`,
+	SQLForTables:     tablesSql,
 	TypeConverterFor: typeNameToConv,
 	TableNameField:   "tname",
 	ColumnNameField:  "name",

--- a/dialect/oracle/tables.sql
+++ b/dialect/oracle/tables.sql
@@ -1,0 +1,3 @@
+select  *
+  from  tab
+ where  tname not like 'BIN$%'

--- a/dialect/postgresql/columns.sql
+++ b/dialect/postgresql/columns.sql
@@ -1,0 +1,11 @@
+select  attname as "NAME",
+        case 
+            when attnotnull then 'NOT NULL'
+            else 'NULL'
+        end as "NULL?",
+        format_type(atttypid, atttypmod) as "TYPE"
+  from  pg_attribute
+ where  attrelid = to_regclass($1)::oid
+   and  attnum > 0
+   and  not attisdropped
+ order  by attnum

--- a/dialect/postgresql/main.go
+++ b/dialect/postgresql/main.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	_ "embed"
 	"fmt"
 	"strings"
 	"time"
@@ -10,6 +11,12 @@ import (
 	"github.com/hymkor/sqlbless/dialect"
 	"github.com/hymkor/sqlbless/internal/misc"
 )
+
+//go:embed tables.sql
+var tablesSql string
+
+//go:embed columns.sql
+var columnsSql string
 
 var postgresTypeNameToFormat = map[string][2]string{
 	"TIMESTAMPTZ": [2]string{"TIMESTAMP WITH TIME ZONE", dialect.DateTimeTzLayout},
@@ -44,55 +51,9 @@ func (ph *placeHolder) Values() (result []any) {
 }
 
 var postgresSpec = &dialect.Entry{
-	Usage: "sqlbless postgres://<USERNAME>:<PASSWORD>@<HOSTNAME>:<PORT>/<DBNAME>?sslmode=disable",
-	SQLForColumns: `
-		with target as (
-			select to_regclass($1)::oid as oid
-		)
-		select
-			a.attname as "NAME",
-			case a.attnotnull
-				when true then 'NOT NULL'
-				else 'NULL'
-			end as "NULL?",
-			format_type(a.atttypid, a.atttypmod) as "TYPE"
-		from target t
-		join pg_attribute a
-		  on a.attrelid = t.oid
-		where a.attnum > 0
-		  and not a.attisdropped
-		order by a.attnum`,
-	SQLForTables: `
-		select
-			n.nspname || '.' || c.relname as full_name,
-			n.nspname as table_schema,
-			c.relname as table_name,
-			case c.relkind
-				when 'r' then 'BASE TABLE'
-				when 'p' then 'PARTITIONED TABLE'
-				when 'v' then 'VIEW'
-				when 'm' then 'MATERIALIZED VIEW'
-				when 'f' then 'FOREIGN TABLE'
-			end as table_type,
-			c.reltuples::bigint as estimated_rows,
-			obj_description(c.oid,'pg_class') as remarks
-		from pg_class c
-		join pg_namespace n
-		  on n.oid = c.relnamespace
-		where c.relkind in ('r','p','v','m','f')
-		order by
-			case n.nspname
-				when 'pg_catalog' then 9
-				when 'information_schema' then 8
-				else 0
-			end,
-			case c.relkind
-				when 'r' then 0
-				when 'p' then 1
-				else 9
-			end,
-			n.nspname,
-			c.relname`,
+	Usage:             "sqlbless postgres://<USERNAME>:<PASSWORD>@<HOSTNAME>:<PORT>/<DBNAME>?sslmode=disable",
+	SQLForColumns:     columnsSql,
+	SQLForTables:      tablesSql,
 	TypeConverterFor:  postgresTypeNameToConv,
 	PlaceHolder:       &placeHolder{},
 	TableNameField:    "full_name",

--- a/dialect/postgresql/tables.sql
+++ b/dialect/postgresql/tables.sql
@@ -1,0 +1,29 @@
+select  n.nspname || '.' || c.relname as full_name,
+        n.nspname as table_schema,
+        c.relname as table_name,
+        case c.relkind
+            when 'r' then 'BASE TABLE'
+            when 'p' then 'PARTITIONED TABLE'
+            when 'v' then 'VIEW'
+            when 'm' then 'MATERIALIZED VIEW'
+            when 'f' then 'FOREIGN TABLE'
+        end as table_type,
+        c.reltuples::bigint as estimated_rows,
+        obj_description(c.oid,'pg_class') as remarks
+  from  pg_class c
+  join  pg_namespace n
+    on  n.oid = c.relnamespace
+ where  c.relkind in ('r','p','v','m','f')
+ order  by
+        case n.nspname
+            when 'pg_catalog' then 9
+            when 'information_schema' then 8
+            else 0
+        end,
+        case c.relkind
+            when 'r' then 0
+            when 'p' then 1
+            else 9
+        end,
+        n.nspname,
+        c.relname

--- a/dialect/sqlite/columns.sql
+++ b/dialect/sqlite/columns.sql
@@ -1,0 +1,1 @@
+PRAGMA {schema.}table_info({table})

--- a/dialect/sqlite/main.go
+++ b/dialect/sqlite/main.go
@@ -2,6 +2,7 @@ package sqlite
 
 import (
 	"database/sql"
+	_ "embed"
 	"fmt"
 	"strings"
 	"time"
@@ -12,17 +13,18 @@ import (
 	"github.com/hymkor/sqlbless/internal/misc"
 )
 
+//go:embed tables.sql
+var tablesSql string
+
+//go:embed columns.sql
+var columnsSql string
+
 var Entry = &dialect.Entry{
-	Usage: "sqlbless sqlite3 :memory: OR <FILEPATH>",
-	SQLForTables: `
-	select 'main' as schema,name,rootpage,sql from sqlite_master
-	where type = 'table'
-	union all
-	select 'temp' as schema,name,rootpage,sql from sqlite_temp_master
-	where type = 'table'`,
+	Usage:             "sqlbless sqlite3 :memory: OR <FILEPATH>",
+	SQLForTables:      tablesSql,
 	TypeConverterFor:  typeNameToConv,
 	PlaceHolder:       &placeHolder{},
-	SQLForColumns:     `PRAGMA {schema.}table_info({table})`,
+	SQLForColumns:     columnsSql,
 	TableNameField:    "name",
 	ColumnNameField:   "name",
 	IsTransactionSafe: canUseInTransaction,

--- a/dialect/sqlite/tables.sql
+++ b/dialect/sqlite/tables.sql
@@ -1,0 +1,13 @@
+select  'main' as schema,
+        name,
+        rootpage,
+        sql
+  from  sqlite_master
+ where  type = 'table'
+ union  all
+select 'temp' as schema,
+        name,
+        rootpage,
+        sql
+  from  sqlite_temp_master
+ where  type = 'table'

--- a/dialect/sqlserver/main.go
+++ b/dialect/sqlserver/main.go
@@ -11,8 +11,11 @@ import (
 	"github.com/hymkor/sqlbless/dialect"
 )
 
+//go:embed tables.sql
+var tablesSql string
+
 //go:embed columns.sql
-var columnSql string
+var columnsSql string
 
 var typeSpec = map[string][2]string{
 	"DATE": {
@@ -66,8 +69,8 @@ func formatValue(typeName string, value any) (string, bool) {
 
 var sqlServerSpec = &dialect.Entry{
 	Usage:            "sqlbless sqlserver://@<HOSTNAME>?database=<DBNAME>",
-	SQLForColumns:    columnSql,
-	SQLForTables:     `select * from sys.tables`,
+	SQLForColumns:    columnsSql,
+	SQLForTables:     tablesSql,
 	TypeConverterFor: typeNameToConv,
 	PlaceHolder:      &dialect.PlaceHolderName{Mark: "@", Prefix: "v"},
 	TableNameField:   "name",

--- a/dialect/sqlserver/tables.sql
+++ b/dialect/sqlserver/tables.sql
@@ -1,0 +1,2 @@
+select  *
+  from  sys.tables


### PR DESCRIPTION
- Refactor: dialect/postgresql: move SQLs from main.go to *.sql using "embed"
- Refactor: dialect/mysql: move SQLs from main.go to *.sql using "embed"
- Refactor: dialect/sqlite: move SQLs from main.go to *.sql using "embed"
- Refactor: dialect/oracle: move SQLs from main.go to *.sql using "embed"
- Refactor: dialect/sqlserver: move SQLs from main.go to *.sql using "embed"
